### PR TITLE
Fix bug: hiding a deck, then hiding another deck, unhides the first.

### DIFF
--- a/src/components/views/decks/DecksList.tsx
+++ b/src/components/views/decks/DecksList.tsx
@@ -201,7 +201,7 @@ export default function DecksList() {
       newList.push(id);
       setDbHiddenDecks(newList);
     },
-    [showHidden, dispatch]
+    [hiddenDecks, showHidden, dispatch]
   );
 
   const unhideDeck = useCallback(
@@ -213,7 +213,7 @@ export default function DecksList() {
       }
       setDbHiddenDecks(newList);
     },
-    [showHidden, dispatch]
+    [hiddenDecks, showHidden, dispatch]
   );
 
   return (


### PR DESCRIPTION
This bug was not reported separately, but was mentioned in https://github.com/mtgatool/mtgatool-desktop/issues/15
quote:

    Reproduction: archiving - There appears to be an index error. Let me know if you wish me to make a separate report for this:

    Go to the deck list
    Click the eye icon to archive a deck (A) - the deck (A) is removed
    Click the eye icon in the deck (B) that now shows in the position the deck in step 2 was in
    Observe that the deck (A) is now shown on the deck list again. Deck (B) is hidden

The hideDeck callback was operating with stale data meaning it constantly reset the last change each time a new change was made.