### PR TITLE
Fix #16 order by winrate does not work

### DIFF
--- a/src/components/views/decks/DecksList.tsx
+++ b/src/components/views/decks/DecksList.tsx
@@ -107,31 +107,14 @@ export default function DecksList() {
   const filteredData = useMemo(() => {
     if (!fullStats) return [];
 
-    const latestDeckHashesArray = Object.keys(fullStats.decks).map((id) => {
-      const hashes = fullStats.decks[id];
-      let latestTimestamp = fullStats.deckIndex[hashes[0]].lastUsed;
-      let latestHash = hashes[0];
+      const isDefined = (item: StatsDeck | undefined): item is StatsDeck => {  return !!item}
 
-      hashes.forEach((h) => {
-        if (latestTimestamp < fullStats.deckIndex[h].lastUsed) {
-          const d = fullStats.deckIndex[h];
-          latestTimestamp = d.lastUsed;
-          latestHash = h;
-        }
-      });
+      const decksForFiltering = Object.keys(fullStats.decks)
+          .map((id) => {
+            return getDeckWithStats(id);
+          })
+          .filter(isDefined);
 
-      return latestHash;
-    });
-
-    const decksForFiltering = latestDeckHashesArray
-      .map((hash) => fullStats.deckIndex[hash])
-      .map((d) => {
-        return {
-          ...d,
-          lastUsed: new Date(d.lastUsed).getTime(),
-          colors: d.colors > 32 ? d.colors - 32 : d.colors,
-        };
-      });
 
     let newFilters = unsetFilter(filters, "inarraystring");
     if (showHidden !== "true") {


### PR DESCRIPTION
The issue here was that the decks list show aggregated data over all versions of the deck. But the sort was sorting based on only the latest hash for that deck. This means the sort order and the winrate values displayed did not match up.

There are two ways to correct this:
1. Keep the current aggregated display, and change the sort order to match
2. Keep the current latest hash sort order, and change the display to match

I went with 1 for this PR. Please let me know if you prefer it the other way around.

https://github.com/mtgatool/mtgatool-desktop/issues/16