### PR TITLE
#36 - added deck sort order to redux state

### DIFF
--- a/src/components/views/decks/DecksList.tsx
+++ b/src/components/views/decks/DecksList.tsx
@@ -27,7 +27,10 @@ import setLocalSetting from "../../../utils/setLocalSetting";
 import setDbHiddenDecks from "../../../toolDb/setDbHiddenDecks";
 import Section from "../../ui/Section";
 import FilterSection from "../../ui/FilterSection";
-import { setDecksFilters } from "../../../redux/slices/FilterSlice";
+import {
+  setDecksFilters,
+  setDeckSort,
+} from "../../../redux/slices/FilterSlice";
 
 interface DeckListProps {
   openHistoryStatsPopup: () => void;
@@ -41,6 +44,7 @@ export default function DecksList(props: DeckListProps) {
   const [colorFilterState, setColorFilterState] = useState(31);
   const [deckNameFilterState, setDeckNameFilterState] = useState("");
   const fullStats = useSelector((state: AppState) => state.mainData.fullStats);
+  const sortValue = useSelector((state: AppState) => state.filter.deckSort);
   const hiddenDecks = useSelector(
     (state: AppState) => state.mainData.hiddenDecks
   );
@@ -92,11 +96,6 @@ export default function DecksList(props: DeckListProps) {
     },
     [fullStats]
   );
-
-  const [sortValue, setSortValue] = useState<Sort<StatsDeck>>({
-    key: "lastUsed",
-    sort: -1,
-  });
 
   const filteredData = useMemo(() => {
     if (!fullStats) return [];
@@ -228,7 +227,7 @@ export default function DecksList(props: DeckListProps) {
       </Section>
       <Section style={{ margin: "16px 0", flexDirection: "column" }}>
         <SortControls<StatsDeck>
-          setSortCallback={setSortValue}
+          setSortCallback={(s: Sort<StatsDeck>) => dispatch(setDeckSort(s))}
           defaultSort={sortValue}
           columnKeys={["lastUsed", "name", "winrate", "totalGames", "colors"]}
           columnNames={[

--- a/src/redux/slices/FilterSlice.ts
+++ b/src/redux/slices/FilterSlice.ts
@@ -13,6 +13,7 @@ import { StatsDeck } from "../../types/dbTypes";
 import { AppState } from "../stores/rendererStore";
 import setFilter from "../../utils/tables/filters/setFilter";
 import setLocalSetting from "../../utils/setLocalSetting";
+import { Sort } from "../../components/SortControls";
 
 export type DateOption =
   | "All Time"
@@ -80,9 +81,7 @@ const calculateAllMatchDataFilters = (): Filters<MatchData> => {
 };
 
 const calculateAllDeckFilters = (): Filters<StatsDeck> => {
-  const filters: FilterTypeBase[] = [];
-
-  return <Filters<StatsDeck>>filters;
+  return <Filters<StatsDeck>>[];
 };
 
 const initialFilterState = {
@@ -91,6 +90,10 @@ const initialFilterState = {
   eventsFilter: getLocalSetting("filterEventOptions"),
   matchDataFilters: calculateAllMatchDataFilters(),
   deckFilters: calculateAllDeckFilters(),
+  deckSort: {
+    key: "lastUsed",
+    sort: -1,
+  } as Sort<StatsDeck>,
 };
 
 type FilterState = typeof initialFilterState;
@@ -171,6 +174,12 @@ const filterSlice = createSlice({
     resetDecksFilters: (state: FilterState): void => {
       state.deckFilters = calculateAllDeckFilters();
     },
+    setDeckSort: (
+      state: FilterState,
+      action: PayloadAction<Sort<StatsDeck>>
+    ): void => {
+      state.deckSort = action.payload;
+    },
   },
 });
 
@@ -180,6 +189,7 @@ export const {
   setEvents,
   setMatchDataFilters,
   setDecksFilters,
+  setDeckSort,
 } = filterSlice.actions;
 
 // Selectors

--- a/src/utils/tables/doDecksFilter.ts
+++ b/src/utils/tables/doDecksFilter.ts
@@ -17,7 +17,7 @@ export default function doDecksFilter(
   let filteredData = data;
 
   filters.forEach((filter) => {
-    console.log(filter, filteredData);
+    // console.log(filter, filteredData);
     switch (filter.type) {
       case "string":
         if (filter.id === "name" || filter.id === "playerId") {


### PR DESCRIPTION
The contentWrapper is getting re-rendered over and over and the sort order was reset because the deck list component is completely rebuilt each time. I could not disgnose why this was happening so I moved the deck sort into the redux state for filters so that it is restored each time.

This is a worthwhile change anyway imo as it means the sort is remembered when the user looks at other views, but it would be a good idea to check why this is re-rendering so often at some point.

The re-rendering stops after about 30 seconds.

fixes #36 