### PR TITLE
Add nix package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.callPackage ./package.nix {}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+let
+  version = "6.7.5";
+  pname = "mtgatool-desktop";
+
+  src = fetchurl {
+    url = "https://github.com/mtgatool/${pname}/releases/download/v${version}/${pname}-${version}.AppImage";
+    hash = "sha256-xNw8oT1BYmmsq861pIZsOBdj1hh0G32d5gJBwMwlJiY=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  meta = {
+    homepage = "https://mtgatool.com/";
+    downloadPage = "https://github.com/mtgatool/${pname}/releases/tag/v${version}";
+    changelog = "https://mtgatool.com/release-notes";
+    description = "MTG Arena Tool is a collection browser, a deck tracker and a statistics manager. Explore which decks you played against and what other players are brewing. MTG Arena Tool is all about improving your Magic Arena experience.";
+    license = lib.licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
This pull request adds a nix package which allows to build and run this app under [NixOS](https://nixos.org/). The build just fetches and wraps the already existing app image and therefore does not require additional maintenance. Please note that even thought it builds just fine, it will fail to actually run which may be related to the other issues on linux.