### PR TITLE
Bring back the post-match overview, and fix the GRE bug it uncovered

### DIFF
--- a/src/background/__tests__/postStats.spec.js
+++ b/src/background/__tests__/postStats.spec.js
@@ -1,0 +1,69 @@
+import path from "path";
+
+import arenaLogWatcher from "../arena-log-watcher";
+import logEntrySwitch from "../logEntrySwitch";
+import globalStore from "../store";
+
+jest.setTimeout(20000);
+
+beforeEach(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+
+function replayLog() {
+  return new Promise((resolve) => {
+    arenaLogWatcher.start({
+      path: path.join(__dirname, "test.log"),
+      chunkSize: 268435440,
+      onLogEntry: logEntrySwitch,
+      onError: console.error,
+      onFinish: resolve,
+    });
+  });
+}
+
+// These feed the post-match overview. Every one of them was already being
+// computed except the timeline, whose accumulator existed with no call sites —
+// so it silently stayed empty. That is exactly the kind of regression a replay
+// catches and a type never will.
+describe("post-match stats", () => {
+  it("accumulates player, opponent and timeline stats from a real log", async () => {
+    await replayLog();
+
+    const { playerStats, oppStats, statsHeatMap, totalTurns } =
+      globalStore.currentMatch;
+
+    expect(totalTurns).toBeGreaterThan(0);
+
+    // Both players took damage and paid mana over the match.
+    expect(playerStats.manaUsed).toBeGreaterThan(0);
+    expect(oppStats.manaUsed).toBeGreaterThan(0);
+    expect(playerStats.lifeLost + oppStats.lifeLost).toBeGreaterThan(0);
+
+    // Life totals are the "life remaining" blocks: one per life change.
+    expect(playerStats.lifeTotals.length).toBeGreaterThan(0);
+    expect(oppStats.lifeTotals.length).toBeGreaterThan(0);
+
+    // Damage is keyed by the grpId that dealt it, for the DMG card.
+    expect(Object.keys(playerStats.damage).length).toBeGreaterThan(0);
+
+    // The timeline: entries for both seats, coalesced per turn and phase.
+    expect(statsHeatMap.length).toBeGreaterThan(0);
+    expect(new Set(statsHeatMap.map((h) => h.seat)).size).toBe(2);
+    statsHeatMap.forEach((heat) => {
+      expect(heat.value).toBeGreaterThan(0);
+      expect(heat.phase).toBeTruthy();
+    });
+
+    // Coalescing means no two consecutive entries share seat+turn+phase.
+    statsHeatMap.slice(1).forEach((heat, i) => {
+      const prev = statsHeatMap[i];
+      expect(
+        heat.seat === prev.seat &&
+          heat.turn === prev.turn &&
+          heat.phase === prev.phase
+      ).toBe(false);
+    });
+  });
+});

--- a/src/background/greToClientInterpreter.ts
+++ b/src/background/greToClientInterpreter.ts
@@ -70,7 +70,14 @@ function changePriority(previous: number, current: number, time: number): void {
   });
 }
 
-function _setHeat(seat: number, value: number): void {
+/**
+ * Add to the match timeline.
+ *
+ * One entry per (seat, turn, phase): anything a player does inside the same
+ * phase accumulates into a single bar rather than adding a new one, which is
+ * what keeps a turn with a dozen mana payments from swamping the chart.
+ */
+function setHeat(seat: number, value: number): void {
   const { turnInfo } = globalStore.currentMatch;
   const heat = {
     value,
@@ -242,6 +249,7 @@ const AnnotationType_ZoneTransfer = (ann: Annotations): void => {
       player: seat,
     };
     addCardCast(cast);
+    setHeat(seat, 1);
 
     actionLog({
       seat: obj.controllerSeatId || seat,
@@ -512,6 +520,8 @@ const AnnotationType_DamageDealt = (ann: Annotations): void => {
     pstats.damage[affectorGrpId] = (prev || 0) + dmg;
   }
 
+  setHeat(affector.controllerSeatId || 0, 1);
+
   actionLog({
     seat: affector.controllerSeatId || 0,
     timestamp: globalStore.currentMatch.logTime.getTime(),
@@ -541,6 +551,8 @@ const AnnotationType_ModifiedLife = (ann: Annotations): void => {
     else globalStore.currentMatch.oppStats.lifeLost += lifeAbs;
     globalStore.currentMatch.oppStats.lifeTotals.push(Math.max(0, total));
   }
+
+  setHeat(affected, 1);
 
   actionLog({
     seat: affected,
@@ -685,6 +697,8 @@ const AnnotationType_ManaPaid = (ann: Annotations): void => {
   } else {
     globalStore.currentMatch.oppStats.manaUsed += 1;
   }
+
+  setHeat(affector, 1);
 };
 
 function annotationsSwitch(ann: Annotations, type: AnnotationType): void {

--- a/src/background/greToClientInterpreter.ts
+++ b/src/background/greToClientInterpreter.ts
@@ -1306,10 +1306,20 @@ const GREMessageType_GameStateMessage = (msg: GREToClientMessage): void => {
 
   if (!duplicate) {
     processAnnotations();
-    checkForStartingLibrary(gameState);
     forceDeckUpdate();
     updateDeck();
   }
+
+  // Runs for re-delivered messages too. The opening hand can only be read at
+  // the instant a player message carries a MulliganResp, and that message can
+  // arrive before the zones and game objects it needs to resolve the hand into
+  // card ids — in which case the first attempt finds nothing and the only
+  // other chance is the re-delivery. Skipping those lost game one's hand.
+  //
+  // Safe to repeat: it assigns rather than accumulates. The hand is stored at
+  // its mulligan number, so a second pass overwrites the same slot instead of
+  // appending a phantom mulligan.
+  checkForStartingLibrary(gameState);
 
   // Last, so the result and the final player state above have landed first.
   // Deliberately not gated on ordering: the conclusion is often exactly what a

--- a/src/background/greToClientInterpreter.ts
+++ b/src/background/greToClientInterpreter.ts
@@ -57,6 +57,15 @@ import countValues from "../utils/countValues";
 import useSet from "../utils/useSet";
 import objectClone from "../utils/objectClone";
 
+/**
+ * Game state message ids already handled this game.
+ *
+ * The GRE both re-delivers messages and delivers them late, so the id alone
+ * does not say whether a message is new — see the handler for why a high-water
+ * mark is not enough. Reset whenever a new game starts.
+ */
+let processedMsgIds = new Set<number>();
+
 function changePriority(previous: number, current: number, time: number): void {
   const priorityTimers = objectClone(globalStore.currentMatch.priorityTimers);
   priorityTimers.timers[previous] += time - priorityTimers.last;
@@ -1211,36 +1220,61 @@ function checkTurnDiff(turnInfo: TurnInfo): void {
 const GREMessageType_GameStateMessage = (msg: GREToClientMessage): void => {
   const { currentMatch } = globalStore;
 
-  if (msg.msgId) {
+  // A message id below the highest one seen means one of two very different
+  // things, and only a record of what was actually handled tells them apart:
+  //
+  //  - a genuinely late event. The GRE resolves a whole state server-side and
+  //    emits its conclusion before the events that produced it, so the message
+  //    carrying the killing blow can arrive after the message saying the game
+  //    is over. It must be processed or the match loses its final damage.
+  //  - a re-delivery of something already handled. Processing it again counts
+  //    the same life change, mana payment and damage twice.
+  //
+  // Comparing against a high-water mark cannot separate them: it discards the
+  // late events along with the repeats. So the ids actually processed are kept
+  // for the duration of the game.
+  const duplicate = !!msg.msgId && processedMsgIds.has(msg.msgId);
+
+  if (msg.msgId && !duplicate) {
     console.log(`Message id > ${msg.msgId} (${currentMatch.msgId})`);
 
-    if (
-      !currentMatch.msgId ||
-      msg.msgId === 1 ||
-      msg.msgId < currentMatch.msgId
-    ) {
-      // New game, reset per-game fields.
+    // A real new game restarts the numbering at 1 — checked before the id is
+    // recorded, so a re-delivered "1" cannot wipe a game in progress.
+    if (!currentMatch.msgId || msg.msgId === 1) {
       console.warn("Reset current game");
       resetCurrentGame();
+      processedMsgIds = new Set();
       setGameBeginTime(globalStore.currentMatch.logTime);
     }
-    setCurrentMatchMany({ msgId: msg.msgId });
+
+    processedMsgIds.add(msg.msgId);
+
+    // High-water mark only; never rewound, since it is what "new game" and the
+    // stats capture are judged against.
+    if (msg.msgId > (currentMatch.msgId || 0)) {
+      setCurrentMatchMany({ msgId: msg.msgId });
+    }
   }
 
   const gameState = msg.gameStateMessage;
   if (gameState) {
+    // Read from every message, in order or not: these are assignments of the
+    // current truth rather than accumulations, so applying them twice is
+    // harmless — and a late message is frequently the one carrying the result
+    // and the final player state.
     if (gameState.gameInfo) {
       setGameInfo(gameState.gameInfo);
       if (gameState.gameInfo.matchID) {
         setMatchId(gameState.gameInfo.matchID);
         setMatchStarted(true);
       }
-      if (gameState.gameInfo.stage == "GameStage_GameOver") {
-        getMatchGameStats();
-      }
     }
 
-    if (gameState.turnInfo) {
+    if (gameState.players) {
+      setPlayers(gameState.players);
+    }
+
+    if (gameState.turnInfo && !duplicate) {
       checkTurnDiff(gameState.turnInfo);
       setTurnInfo(gameState.turnInfo);
     }
@@ -1254,27 +1288,35 @@ const GREMessageType_GameStateMessage = (msg: GREToClientMessage): void => {
       });
     }
     */
-    if (gameState.zones) {
+    // Everything below accumulates, so a re-delivered message must not reach
+    // it — annotations especially, since `processAnnotations` is what totals
+    // life, mana and damage.
+    if (gameState.zones && !duplicate) {
       setManyZones(gameState.zones);
     }
 
-    if (gameState.players) {
-      setPlayers(gameState.players);
-    }
-
-    if (gameState.gameObjects) {
+    if (gameState.gameObjects && !duplicate) {
       setManyGameObjects(gameState.gameObjects);
     }
 
-    if (gameState.annotations) {
+    if (gameState.annotations && !duplicate) {
       setManyAnnotations(gameState.annotations);
     }
   }
 
-  processAnnotations();
-  checkForStartingLibrary(gameState);
-  forceDeckUpdate();
-  updateDeck();
+  if (!duplicate) {
+    processAnnotations();
+    checkForStartingLibrary(gameState);
+    forceDeckUpdate();
+    updateDeck();
+  }
+
+  // Last, so the result and the final player state above have landed first.
+  // Deliberately not gated on ordering: the conclusion is often exactly what a
+  // late message carries, and getMatchGameStats is written to be repeatable.
+  if (gameState?.gameInfo?.stage == "GameStage_GameOver") {
+    getMatchGameStats();
+  }
 };
 
 // Some game state messages are sent as queued

--- a/src/background/saveMatch.ts
+++ b/src/background/saveMatch.ts
@@ -52,16 +52,13 @@ function generateInternalMatch(): InternalMatch {
     currentMatch.gameInfo.results
   );
 
-  /*
+  const newMatch: InternalMatch = {
     postStats: {
       statsHeatMap: currentMatch.statsHeatMap,
       totalTurns: currentMatch.totalTurns,
       playerStats: currentMatch.playerStats,
       oppStats: currentMatch.oppStats,
     },
-  */
-
-  const newMatch: InternalMatch = {
     onThePlay: currentMatch.onThePlay,
     id: currentMatch.matchId,
     date: currentMatch.logTime.toISOString() || new Date().toISOString(),

--- a/src/broadcastChannel/mainChannelListeners.ts
+++ b/src/broadcastChannel/mainChannelListeners.ts
@@ -9,6 +9,7 @@ import upsertDbCards from "../data/upsertDbCards";
 import upsertDbInventory from "../data/upsertDbInventory";
 import upsertDbRank from "../data/upsertDbRank";
 import upsertDbSeason from "../data/upsertDbSeason";
+import showPostMatchOverview from "../postmatch/showPostMatchOverview";
 import readCards from "../reader/readCards";
 import readPlayerId from "../reader/readPlayerid";
 import UICheckAdmin from "../reader/uiCheckAdmin";
@@ -131,6 +132,11 @@ export default function mainChannelListeners() {
       if (msg.data.value.eventId !== "AIBotMatch") {
         setDbMatch(msg.data.value);
       }
+
+      // The overview is shown for bot matches too, even though those are never
+      // persisted above — it reads the match handed to it here, not the
+      // database, so there is nothing to exclude it from.
+      showPostMatchOverview(msg.data.value);
     }
 
     if (msg.data.type === "DRAFT_STATUS") {

--- a/src/electronIndex.tsx
+++ b/src/electronIndex.tsx
@@ -13,6 +13,7 @@ import mainChannelListeners from "./broadcastChannel/mainChannelListeners";
 import App from "./components/App";
 import Hover from "./hover";
 import Overlay from "./overlay";
+import PostMatch from "./postmatch";
 import reduxAction from "./redux/reduxAction";
 import store from "./redux/stores/rendererStore";
 import * as serviceWorker from "./serviceWorker";
@@ -20,6 +21,7 @@ import {
   ALL_OVERLAYS,
   WINDOW_BACKGROUND,
   WINDOW_HOVER,
+  WINDOW_POSTMATCH,
   WINDOW_UPDATER,
 } from "./types/app";
 import Updater from "./updater";
@@ -77,6 +79,30 @@ if (title == WINDOW_UPDATER) {
       <React.StrictMode>
         <Provider store={store}>
           <NextHover />
+        </Provider>
+      </React.StrictMode>,
+      document.getElementById("root")
+    );
+  }
+} else if (title == WINDOW_POSTMATCH) {
+  defaultLocalSettings();
+  ReactDOM.render(
+    <React.StrictMode>
+      <Provider store={store}>
+        <PostMatch />
+      </Provider>
+    </React.StrictMode>,
+    document.getElementById("root")
+  );
+
+  if (module.hot && process.env.NODE_ENV === "development") {
+    module.hot.accept();
+    // eslint-disable-next-line global-require
+    const NextPostMatch = require("./postmatch/index").default;
+    ReactDOM.render(
+      <React.StrictMode>
+        <Provider store={store}>
+          <NextPostMatch />
         </Provider>
       </React.StrictMode>,
       document.getElementById("root")

--- a/src/index.scss
+++ b/src/index.scss
@@ -32,6 +32,7 @@
 @import "scss/topNav.scss";
 
 @import "scss/livematchView.scss";
+@import "scss/postMatch.scss";
 @import "scss/decksView.scss";
 @import "scss/matchView.scss";
 @import "scss/homeView.scss";

--- a/src/postmatch/LifeBar.tsx
+++ b/src/postmatch/LifeBar.tsx
@@ -4,12 +4,17 @@ interface LifeBarProps {
 }
 
 /**
- * Life remaining: one block per life change, the player's run then the
- * opponent's, each block as wide as the life total it records.
+ * Life remaining: one block per life change, each as wide as the life total it
+ * records.
  *
- * So a game that stayed level splits down the middle, and a player taken from
- * 20 to 0 in one hit contributes a single wide block followed by nothing —
- * the shape of the game is legible without reading a number.
+ * Both runs start at the centre seam and drain outwards — the player's to the
+ * left, the opponent's to the right — so the highest totals meet in the
+ * middle and the bar narrows towards whichever side lost more life. Reading
+ * outwards from the centre is reading forwards in time, on both sides.
+ *
+ * That is why the player's run is reversed and the opponent's is not: they are
+ * both recorded oldest-first, but only the opponent's is drawn away from the
+ * seam in that order.
  *
  * Only real life changes are drawn; a player who was never touched has no
  * blocks at all, which is exactly what the parser recorded.
@@ -43,7 +48,9 @@ export default function LifeBar(props: LifeBarProps): JSX.Element | null {
     <div className="postmatch-stat">
       <div className="postmatch-stat-title">Life Remaining</div>
       <div className="postmatch-life-bar">
-        {player.map((life, i) => block(life, "player", `p-${i}`))}
+        {[...player]
+          .reverse()
+          .map((life, i) => block(life, "player", `p-${i}`))}
         {opp.map((life, i) => block(life, "opp", `o-${i}`))}
       </div>
     </div>

--- a/src/postmatch/LifeBar.tsx
+++ b/src/postmatch/LifeBar.tsx
@@ -8,13 +8,18 @@ interface LifeBarProps {
  * records.
  *
  * Both runs start at the centre seam and drain outwards — the player's to the
- * left, the opponent's to the right — so the highest totals meet in the
- * middle and the bar narrows towards whichever side lost more life. Reading
- * outwards from the centre is reading forwards in time, on both sides.
+ * left, the opponent's to the right. Reading outwards from the centre is
+ * reading forwards in time, on both sides.
  *
  * That is why the player's run is reversed and the opponent's is not: they are
  * both recorded oldest-first, but only the opponent's is drawn away from the
  * seam in that order.
+ *
+ * Each side owns exactly half the width and divides its own half between its
+ * own blocks, so the seam sits dead centre whatever happened in the game. The
+ * comparison the bar makes is therefore within a side — how a player's life
+ * fell over time — and not between the two totals, which the Life Lost bar
+ * already shows.
  *
  * Only real life changes are drawn; a player who was never touched has no
  * blocks at all, which is exactly what the parser recorded.
@@ -23,21 +28,27 @@ export default function LifeBar(props: LifeBarProps): JSX.Element | null {
   const { player, opp } = props;
   if (player.length === 0 && opp.length === 0) return null;
 
-  const grand =
-    player.reduce((a, b) => a + b, 0) + opp.reduce((a, b) => a + b, 0);
+  const sum = (run: number[]): number => run.reduce((a, b) => a + b, 0);
 
-  // Every snapshot is zero (both players dead at 0) — nothing to size blocks
-  // by, so fall back to equal widths rather than collapsing the row.
-  const even = grand === 0;
-  const count = player.length + opp.length;
-  const widthFor = (life: number): string =>
-    even ? `${100 / count}%` : `${(life / grand) * 100}%`;
+  // A side whose snapshots are all zero has nothing to size blocks by — split
+  // its half evenly rather than collapsing the row to nothing.
+  const widthIn = (life: number, run: number[]): string => {
+    const total = sum(run);
+    return total > 0
+      ? `${(life / total) * 50}%`
+      : `${50 / Math.max(run.length, 1)}%`;
+  };
 
-  const block = (life: number, side: string, key: string): JSX.Element => (
+  const block = (
+    life: number,
+    side: string,
+    key: string,
+    run: number[]
+  ): JSX.Element => (
     <div
       key={key}
       className={`postmatch-life-block ${side}`}
-      style={{ width: widthFor(life) }}
+      style={{ width: widthIn(life, run) }}
       title={`${life} life`}
     >
       <span>{life}</span>
@@ -50,8 +61,8 @@ export default function LifeBar(props: LifeBarProps): JSX.Element | null {
       <div className="postmatch-life-bar">
         {[...player]
           .reverse()
-          .map((life, i) => block(life, "player", `p-${i}`))}
-        {opp.map((life, i) => block(life, "opp", `o-${i}`))}
+          .map((life, i) => block(life, "player", `p-${i}`, player))}
+        {opp.map((life, i) => block(life, "opp", `o-${i}`, opp))}
       </div>
     </div>
   );

--- a/src/postmatch/LifeBar.tsx
+++ b/src/postmatch/LifeBar.tsx
@@ -1,0 +1,51 @@
+interface LifeBarProps {
+  player: number[];
+  opp: number[];
+}
+
+/**
+ * Life remaining: one block per life change, the player's run then the
+ * opponent's, each block as wide as the life total it records.
+ *
+ * So a game that stayed level splits down the middle, and a player taken from
+ * 20 to 0 in one hit contributes a single wide block followed by nothing —
+ * the shape of the game is legible without reading a number.
+ *
+ * Only real life changes are drawn; a player who was never touched has no
+ * blocks at all, which is exactly what the parser recorded.
+ */
+export default function LifeBar(props: LifeBarProps): JSX.Element | null {
+  const { player, opp } = props;
+  if (player.length === 0 && opp.length === 0) return null;
+
+  const grand =
+    player.reduce((a, b) => a + b, 0) + opp.reduce((a, b) => a + b, 0);
+
+  // Every snapshot is zero (both players dead at 0) — nothing to size blocks
+  // by, so fall back to equal widths rather than collapsing the row.
+  const even = grand === 0;
+  const count = player.length + opp.length;
+  const widthFor = (life: number): string =>
+    even ? `${100 / count}%` : `${(life / grand) * 100}%`;
+
+  const block = (life: number, side: string, key: string): JSX.Element => (
+    <div
+      key={key}
+      className={`postmatch-life-block ${side}`}
+      style={{ width: widthFor(life) }}
+      title={`${life} life`}
+    >
+      <span>{life}</span>
+    </div>
+  );
+
+  return (
+    <div className="postmatch-stat">
+      <div className="postmatch-stat-title">Life Remaining</div>
+      <div className="postmatch-life-bar">
+        {player.map((life, i) => block(life, "player", `p-${i}`))}
+        {opp.map((life, i) => block(life, "opp", `o-${i}`))}
+      </div>
+    </div>
+  );
+}

--- a/src/postmatch/StatBar.tsx
+++ b/src/postmatch/StatBar.tsx
@@ -1,0 +1,39 @@
+interface StatBarProps {
+  title: string;
+  player: number;
+  opp: number;
+}
+
+/**
+ * One diverging bar: the player's share growing from the left, the
+ * opponent's from the right, each labelled with its own total.
+ *
+ * A zero on both sides would divide by zero, so it falls back to an even
+ * split — a match where neither player gained life should read as 0 | 0, not
+ * as a blank row.
+ */
+export default function StatBar(props: StatBarProps): JSX.Element {
+  const { title, player, opp } = props;
+  const total = player + opp;
+  const playerPct = total > 0 ? (player / total) * 100 : 50;
+
+  return (
+    <div className="postmatch-stat">
+      <div className="postmatch-stat-title">{title}</div>
+      <div className="postmatch-stat-bar">
+        <div
+          className="postmatch-stat-fill player"
+          style={{ width: `${playerPct}%` }}
+        >
+          <span className="postmatch-stat-value">{player}</span>
+        </div>
+        <div
+          className="postmatch-stat-fill opp"
+          style={{ width: `${100 - playerPct}%` }}
+        >
+          <span className="postmatch-stat-value">{opp}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/postmatch/Timeline.tsx
+++ b/src/postmatch/Timeline.tsx
@@ -42,7 +42,8 @@ export default function Timeline(props: TimelineProps): JSX.Element | null {
         <div className="postmatch-timeline-axis" />
         {heat.map((h, i) => {
           const isPlayer = h.seat === playerSeat;
-          const height = (h.value / max) * 100;
+          // Half, not full: each bar only owns its side of the centre line.
+          const height = (h.value / max) * 50;
           const newTurn = i > 0 && heat[i - 1].turn !== h.turn;
           const phase = PHASE_LABEL[h.phase] || h.phase;
 
@@ -56,9 +57,11 @@ export default function Timeline(props: TimelineProps): JSX.Element | null {
               className={`postmatch-timeline-col${
                 newTurn ? " turn-start" : ""
               }`}
-              title={`Turn ${h.turn} — ${phase} — ${h.value} action${
-                h.value === 1 ? "" : "s"
-              }`}
+              // No turn number: the GRE does not always have one when a heat
+              // entry is recorded (`Heat.turn` is optional for that reason),
+              // and a tooltip reading "Turn undefined" is worse than one that
+              // never mentions turns at all. The separators still mark them.
+              title={`${phase} — ${h.value} action${h.value === 1 ? "" : "s"}`}
             >
               <div
                 className={`postmatch-timeline-bar ${

--- a/src/postmatch/Timeline.tsx
+++ b/src/postmatch/Timeline.tsx
@@ -1,0 +1,75 @@
+import { Heat } from "../types";
+
+interface TimelineProps {
+  heat: Heat[];
+  playerSeat: number;
+  totalTurns: number;
+}
+
+const PHASE_LABEL: Record<string, string> = {
+  Phase_Beginning: "Beginning",
+  Phase_Main1: "First Main",
+  Phase_Combat: "Combat",
+  Phase_Main2: "Second Main",
+  Phase_Ending: "Ending",
+};
+
+/**
+ * The match as a sequence of activity: one column per (seat, turn, phase)
+ * the parser recorded, the player's growing up from the centre line and the
+ * opponent's down.
+ *
+ * Column height is the number of things that player did in that phase —
+ * mana paid, life changed, spells cast, damage dealt — so a turn where
+ * somebody comboed off is visibly taller than a turn where they passed.
+ *
+ * Turn boundaries are drawn as separators rather than as an axis: the
+ * interesting comparison is between adjacent phases, and a full axis at this
+ * width would be unreadable.
+ */
+export default function Timeline(props: TimelineProps): JSX.Element | null {
+  const { heat, playerSeat, totalTurns } = props;
+  if (!heat || heat.length === 0) return null;
+
+  const max = Math.max(...heat.map((h) => h.value), 1);
+
+  return (
+    <div className="postmatch-stat">
+      <div className="postmatch-stat-title">
+        Timeline <span className="postmatch-dim">({totalTurns} turns)</span>
+      </div>
+      <div className="postmatch-timeline">
+        <div className="postmatch-timeline-axis" />
+        {heat.map((h, i) => {
+          const isPlayer = h.seat === playerSeat;
+          const height = (h.value / max) * 100;
+          const newTurn = i > 0 && heat[i - 1].turn !== h.turn;
+          const phase = PHASE_LABEL[h.phase] || h.phase;
+
+          return (
+            <div
+              // Nothing in a heat entry is unique — the same seat can act in
+              // the same phase of the same turn more than once — so position
+              // is the only stable identity here.
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              className={`postmatch-timeline-col${
+                newTurn ? " turn-start" : ""
+              }`}
+              title={`Turn ${h.turn} — ${phase} — ${h.value} action${
+                h.value === 1 ? "" : "s"
+              }`}
+            >
+              <div
+                className={`postmatch-timeline-bar ${
+                  isPlayer ? "player" : "opp"
+                }`}
+                style={{ height: `${height}%` }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/postmatch/createPostMatchWindow.ts
+++ b/src/postmatch/createPostMatchWindow.ts
@@ -47,6 +47,11 @@ export default function createPostMatchWindow(): void {
     // uninteractable on some Linux setups, and "Show overlay frame" is the
     // escape hatch users already know about.
     frame: allSettings.overlayFrame,
+    // macOS draws a shadow around the *window*, not around what is painted in
+    // it, so a transparent window gets a hard rounded outline tracing its
+    // bounds — the panel then looks like it sits inside a frame it does not
+    // have. The card carries its own CSS shadow instead.
+    hasShadow: !allSettings.overlaysTransparency,
     center: true,
     width: 620,
     height: 800,

--- a/src/postmatch/createPostMatchWindow.ts
+++ b/src/postmatch/createPostMatchWindow.ts
@@ -56,6 +56,10 @@ export default function createPostMatchWindow(): void {
     width: 620,
     height: 800,
     resizable: true,
+    // The layout adapts down to roughly half size; past this the bars stop
+    // being readable at all, so the window refuses rather than degrading.
+    minWidth: 320,
+    minHeight: 380,
     alwaysOnTop: false,
     webPreferences: {
       webSecurity: false,

--- a/src/postmatch/createPostMatchWindow.ts
+++ b/src/postmatch/createPostMatchWindow.ts
@@ -1,0 +1,89 @@
+import path from "path";
+import url from "url";
+
+import { Settings } from "../common/defaultConfig";
+import { WINDOW_POSTMATCH } from "../types/app";
+import remote from "../utils/electron/remoteWrapper";
+import getLocalSetting from "../utils/getLocalSetting";
+
+/**
+ * The post-match overview window.
+ *
+ * Deliberately close to `createOverlay` — same transparency, same title
+ * pinning, same dev-tools handling — with the differences that matter for a
+ * window the user is meant to *use* rather than look past:
+ *
+ * - It stays focusable. The overlays call `setFocusable(false)` and
+ *   `setAlwaysOnTop(…, "pop-up-menu")` so clicks fall through to the game;
+ *   doing that here would leave the close button unclickable.
+ * - It is centred and not always-on-top, because the match is over and there
+ *   is nothing underneath left to watch.
+ */
+export default function createPostMatchWindow(): void {
+  if (!remote) return;
+
+  const existing = remote.BrowserWindow.getAllWindows().find(
+    (w: { getTitle: () => string }) => w.getTitle() === WINDOW_POSTMATCH
+  );
+  // A second match can finish before the last overview was dismissed; reuse the
+  // window rather than stacking them. It reads the stashed match on mount, so
+  // reloading is what refreshes it.
+  if (existing) {
+    existing.reload();
+    existing.show();
+    existing.moveTop();
+    return;
+  }
+
+  const allSettings = JSON.parse(getLocalSetting("settings")) as Settings;
+
+  const newWindow = new remote.BrowserWindow({
+    transparent: allSettings.overlaysTransparency,
+    backgroundColor: allSettings.overlaysTransparency ? undefined : "#0d0d0f",
+    title: WINDOW_POSTMATCH,
+    show: false,
+    frame: false,
+    center: true,
+    width: 620,
+    height: 800,
+    resizable: true,
+    alwaysOnTop: false,
+    webPreferences: {
+      webSecurity: false,
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  newWindow.removeMenu();
+
+  // Same trap as the overlays: the app HTML's <title> would overwrite the
+  // window title this window is identified by, and electronIndex would then
+  // render the main app in here instead of the overview.
+  newWindow.on("page-title-updated", (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+  });
+
+  const proc: any = process;
+  newWindow.loadURL(
+    remote.app.isPackaged
+      ? url.format({
+          pathname: path.join(
+            proc.resourcesPath,
+            "app.asar",
+            "build",
+            "index.html"
+          ),
+          protocol: "file:",
+          slashes: true,
+        })
+      : "http://localhost:3001"
+  );
+
+  remote.require("@electron/remote/main").enable(newWindow.webContents);
+
+  newWindow.webContents.once("dom-ready", () => {
+    newWindow.show();
+    newWindow.moveTop();
+  });
+}

--- a/src/postmatch/createPostMatchWindow.ts
+++ b/src/postmatch/createPostMatchWindow.ts
@@ -42,7 +42,11 @@ export default function createPostMatchWindow(): void {
     backgroundColor: allSettings.overlaysTransparency ? undefined : "#0d0d0f",
     title: WINDOW_POSTMATCH,
     show: false,
-    frame: false,
+    // Both governed by the overlay settings, because they answer the same
+    // question for the same reason: a transparent, frameless window is
+    // uninteractable on some Linux setups, and "Show overlay frame" is the
+    // escape hatch users already know about.
+    frame: allSettings.overlayFrame,
     center: true,
     width: 620,
     height: 800,

--- a/src/postmatch/index.tsx
+++ b/src/postmatch/index.tsx
@@ -1,0 +1,235 @@
+import { useMemo } from "react";
+
+import RankIcon from "../components/RankIcon";
+import TopBar from "../components/TopBar";
+import useCard from "../hooks/useCard";
+import { useCardArtCrop } from "../hooks/useCardImage";
+import { CardCast, InternalMatch, MatchPlayerStats } from "../types";
+import remote from "../utils/electron/remoteWrapper";
+import getLocalSetting from "../utils/getLocalSetting";
+import LifeBar from "./LifeBar";
+import StatBar from "./StatBar";
+import Timeline from "./Timeline";
+
+/** The grpId with the highest total in a `damage` map, or 0 for none. */
+function topDamage(stats: MatchPlayerStats | undefined): number {
+  if (!stats?.damage) return 0;
+  const entries = Object.entries(stats.damage);
+  if (entries.length === 0) return 0;
+  const [grpId] = entries.reduce((best, cur) =>
+    cur[1] > best[1] ? cur : best
+  );
+  return Number(grpId);
+}
+
+/** The grpId cast most often by `seat`, or 0 for none. */
+function topCast(casts: CardCast[], seat: number): number {
+  const counts = new Map<number, number>();
+  casts
+    .filter((c) => c.player === seat)
+    .forEach((c) => counts.set(c.grpId, (counts.get(c.grpId) || 0) + 1));
+  if (counts.size === 0) return 0;
+  return [...counts.entries()].reduce((best, cur) =>
+    cur[1] > best[1] ? cur : best
+  )[0];
+}
+
+function duration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+interface CardBadgeProps {
+  grpId: number;
+  label: string;
+}
+
+/** One of the little round "best at X" cards, art-cropped. */
+function CardBadge(props: CardBadgeProps): JSX.Element | null {
+  const { grpId, label } = props;
+  const art = useCardArtCrop(grpId);
+  const card = useCard(grpId);
+  if (!grpId) return null;
+
+  return (
+    <div className="postmatch-badge" title={card?.Name || ""}>
+      <div className="postmatch-badge-label">{label}</div>
+      <div
+        className="postmatch-badge-art"
+        style={art ? { backgroundImage: `url(${art})` } : undefined}
+      />
+    </div>
+  );
+}
+
+export default function PostMatch(): JSX.Element {
+  // Handed over through localStorage by showPostMatchOverview — this window is
+  // created in reaction to the same event that carries the match, so a
+  // broadcast would arrive before it had finished booting.
+  const match = useMemo<InternalMatch | null>(() => {
+    try {
+      const raw = getLocalSetting("postMatchOverview");
+      return raw ? (JSON.parse(raw) as InternalMatch) : null;
+    } catch (e) {
+      return null;
+    }
+  }, []);
+
+  const close = (): void => {
+    if (remote) remote.getCurrentWindow().close();
+  };
+
+  const casts = useMemo<CardCast[]>(
+    () =>
+      Object.values(match?.gameStats || {}).flatMap((g) => g?.cardsCast || []),
+    [match]
+  );
+
+  const playerSeat = match?.player?.seat ?? 1;
+  const oppSeat = match?.opponent?.seat ?? 2;
+
+  const stats = match?.postStats;
+  const pStats = stats?.playerStats;
+  const oStats = stats?.oppStats;
+
+  const playerDmg = topDamage(pStats);
+  const oppDmg = topDamage(oStats);
+  const playerCast = topCast(casts, playerSeat);
+  const oppCast = topCast(casts, oppSeat);
+
+  // The match MVP: whichever single card dealt the most damage on either side.
+  // It headlines the screen, so it is the one card worth showing as art.
+  const mvpGrpId =
+    (pStats?.damage?.[playerDmg] || 0) >= (oStats?.damage?.[oppDmg] || 0)
+      ? playerDmg
+      : oppDmg;
+  const mvpArt = useCardArtCrop(mvpGrpId);
+  const mvpCard = useCard(mvpGrpId);
+  const mvpDamage =
+    pStats?.damage?.[mvpGrpId] || oStats?.damage?.[mvpGrpId] || 0;
+
+  const playerCasts = casts.filter((c) => c.player === playerSeat).length;
+  const oppCasts = casts.filter((c) => c.player === oppSeat).length;
+
+  if (!match) {
+    return (
+      <div className="postmatch-root">
+        <TopBar closeCallback={close} />
+        <div className="postmatch-panel postmatch-empty">
+          No match to show yet.
+        </div>
+      </div>
+    );
+  }
+
+  const won = (match.player?.wins || 0) > (match.opponent?.wins || 0);
+
+  return (
+    <div className="postmatch-root">
+      <TopBar closeCallback={close} />
+
+      <div className="postmatch-panel">
+        {mvpGrpId ? (
+          <div
+            className="postmatch-mvp"
+            style={mvpArt ? { backgroundImage: `url(${mvpArt})` } : undefined}
+          >
+            <div className="postmatch-mvp-shade">
+              <div className="postmatch-mvp-label">Match MVP</div>
+              <div className="postmatch-mvp-name">{mvpCard?.Name || ""}</div>
+              <div className="postmatch-mvp-sub">{mvpDamage} damage dealt</div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="postmatch-header">
+          <div className="postmatch-player">
+            <div className="postmatch-name">
+              {match.player?.name?.split("#")[0]}
+            </div>
+            <RankIcon
+              rank={match.player?.rank}
+              tier={match.player?.tier}
+              step={match.player?.step}
+              percentile={match.player?.percentile}
+              leaderboardPlace={match.player?.leaderboardPlace}
+              format="constructed"
+            />
+          </div>
+
+          <div className="postmatch-center">
+            <div className={`postmatch-result ${won ? "won" : "lost"}`}>
+              {match.player?.wins}:{match.opponent?.wins}
+            </div>
+            <div className="postmatch-dim">Duration</div>
+            <div className="postmatch-duration">
+              {duration(match.duration || 0)}
+            </div>
+          </div>
+
+          <div className="postmatch-player">
+            <div className="postmatch-name">
+              {match.opponent?.name?.split("#")[0]}
+            </div>
+            <RankIcon
+              rank={match.opponent?.rank}
+              tier={match.opponent?.tier}
+              step={match.opponent?.step}
+              percentile={match.opponent?.percentile}
+              leaderboardPlace={match.opponent?.leaderboardPlace}
+              format="constructed"
+            />
+          </div>
+        </div>
+
+        <div className="postmatch-badges">
+          <div className="postmatch-badges-side">
+            <CardBadge grpId={playerDmg} label="DMG" />
+            <CardBadge grpId={playerCast} label="Cast" />
+          </div>
+          <div className="postmatch-badges-sep" />
+          <div className="postmatch-badges-side">
+            <CardBadge grpId={oppDmg} label="DMG" />
+            <CardBadge grpId={oppCast} label="Cast" />
+          </div>
+        </div>
+
+        {/* Everything below comes from postStats, which matches recorded before
+            the overview existed do not have. Those sections are dropped rather
+            than drawn empty. */}
+        {stats ? (
+          <>
+            <LifeBar
+              player={pStats?.lifeTotals || []}
+              opp={oStats?.lifeTotals || []}
+            />
+            <StatBar title="Cards Cast" player={playerCasts} opp={oppCasts} />
+            <StatBar
+              title="Life Gained"
+              player={pStats?.lifeGained || 0}
+              opp={oStats?.lifeGained || 0}
+            />
+            <StatBar
+              title="Life Lost"
+              player={pStats?.lifeLost || 0}
+              opp={oStats?.lifeLost || 0}
+            />
+            <StatBar
+              title="Mana Used"
+              player={pStats?.manaUsed || 0}
+              opp={oStats?.manaUsed || 0}
+            />
+            <Timeline
+              heat={stats.statsHeatMap || []}
+              playerSeat={playerSeat}
+              totalTurns={stats.totalTurns || 0}
+            />
+          </>
+        ) : (
+          <StatBar title="Cards Cast" player={playerCasts} opp={oppCasts} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/postmatch/index.tsx
+++ b/src/postmatch/index.tsx
@@ -97,7 +97,12 @@ export default function PostMatch(): JSX.Element {
   const CloseSVG = process.platform === "darwin" ? MacClose : WinClose;
   const rootClass = `postmatch-root${transparent ? " frameless" : ""}`;
 
-  const chrome = transparent ? (
+  // The close button has to live *inside* the draggable panel, not beside it:
+  // the no-drag carve-out is applied to elements within the drag region, so a
+  // sibling laid over the top keeps rendering and hit-testing normally in the
+  // page while the window drag swallows the actual click. Positioned fixed so
+  // it stays put while the panel scrolls under it.
+  const closeButton = transparent ? (
     <div
       className={`postmatch-close ${
         process.platform === "darwin" ? "mac" : "win"
@@ -107,9 +112,9 @@ export default function PostMatch(): JSX.Element {
     >
       <CloseSVG />
     </div>
-  ) : (
-    <TopBar closeCallback={close} />
-  );
+  ) : null;
+
+  const topBar = transparent ? null : <TopBar closeCallback={close} />;
 
   const casts = useMemo<CardCast[]>(
     () =>
@@ -146,8 +151,9 @@ export default function PostMatch(): JSX.Element {
   if (!match) {
     return (
       <div className={rootClass}>
-        {chrome}
+        {topBar}
         <div className="postmatch-panel postmatch-empty">
+          {closeButton}
           No match to show yet.
         </div>
       </div>
@@ -158,9 +164,10 @@ export default function PostMatch(): JSX.Element {
 
   return (
     <div className={rootClass}>
-      {chrome}
+      {topBar}
 
       <div className="postmatch-panel">
+        {closeButton}
         {mvpGrpId ? (
           <div
             className="postmatch-mvp"

--- a/src/postmatch/index.tsx
+++ b/src/postmatch/index.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
 
+import { ReactComponent as MacClose } from "../assets/images/svg/mac-close.svg";
+import { ReactComponent as WinClose } from "../assets/images/svg/win-close.svg";
 import RankIcon from "../components/RankIcon";
 import TopBar from "../components/TopBar";
 import useCard from "../hooks/useCard";
@@ -80,6 +82,35 @@ export default function PostMatch(): JSX.Element {
     if (remote) remote.getCurrentWindow().close();
   };
 
+  // Transparent windows get the overlay treatment: no title bar, our own close
+  // button, and the card itself as the drag handle — a frame around a floating
+  // translucent panel looks like a mistake. With transparency off the window is
+  // an ordinary opaque one, so it keeps the normal title bar.
+  const transparent = useMemo(() => {
+    try {
+      return !!JSON.parse(getLocalSetting("settings")).overlaysTransparency;
+    } catch (e) {
+      return false;
+    }
+  }, []);
+
+  const CloseSVG = process.platform === "darwin" ? MacClose : WinClose;
+  const rootClass = `postmatch-root${transparent ? " frameless" : ""}`;
+
+  const chrome = transparent ? (
+    <div
+      className={`postmatch-close ${
+        process.platform === "darwin" ? "mac" : "win"
+      }`}
+      onClick={close}
+      title="Close"
+    >
+      <CloseSVG />
+    </div>
+  ) : (
+    <TopBar closeCallback={close} />
+  );
+
   const casts = useMemo<CardCast[]>(
     () =>
       Object.values(match?.gameStats || {}).flatMap((g) => g?.cardsCast || []),
@@ -114,8 +145,8 @@ export default function PostMatch(): JSX.Element {
 
   if (!match) {
     return (
-      <div className="postmatch-root">
-        <TopBar closeCallback={close} />
+      <div className={rootClass}>
+        {chrome}
         <div className="postmatch-panel postmatch-empty">
           No match to show yet.
         </div>
@@ -126,8 +157,8 @@ export default function PostMatch(): JSX.Element {
   const won = (match.player?.wins || 0) > (match.opponent?.wins || 0);
 
   return (
-    <div className="postmatch-root">
-      <TopBar closeCallback={close} />
+    <div className={rootClass}>
+      {chrome}
 
       <div className="postmatch-panel">
         {mvpGrpId ? (

--- a/src/postmatch/showPostMatchOverview.ts
+++ b/src/postmatch/showPostMatchOverview.ts
@@ -1,0 +1,32 @@
+import store from "../redux/stores/rendererStore";
+import { InternalMatch } from "../types";
+import setLocalSetting from "../utils/setLocalSetting";
+import createPostMatchWindow from "./createPostMatchWindow";
+
+/**
+ * Hand a finished match to the overview window and open it.
+ *
+ * Gated on `overlayOverview` — the "Show post-match overview" toggle, which
+ * has been in Settings (and defaulted to on) the whole time this screen did
+ * not exist.
+ */
+export default function showPostMatchOverview(match: InternalMatch): void {
+  if (!store.getState().settings.overlayOverview) return;
+  if (!match) return;
+
+  // The action log is by far the largest field and the overview does not read
+  // it; everything the screen needs lives in postStats, gameStats and the two
+  // player records.
+  const { actionLog: _actionLog, ...overview } = match;
+
+  try {
+    setLocalSetting("postMatchOverview", JSON.stringify(overview));
+  } catch (e) {
+    // A match too large to stringify is not worth taking the app down for.
+    // eslint-disable-next-line no-console
+    console.log("Could not stash the post-match overview", e);
+    return;
+  }
+
+  createPostMatchWindow();
+}

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -352,3 +352,120 @@
     background: linear-gradient(to bottom, #c76a4c, var(--color-r));
   }
 }
+
+// --- narrow / short windows ------------------------------------------------
+//
+// The window is resizable and people shrink it. Everything here still fits at
+// half size; what gives way first is the banner and the timeline, which are
+// the two blocks holding height they don't need, and the per-block life
+// numbers, which stop being legible long before the blocks themselves do.
+//
+// The window itself is clamped (minWidth/minHeight in createPostMatchWindow),
+// so these are the smallest cases that can actually be reached.
+
+@media (max-width: 480px) {
+  .postmatch-mvp {
+    height: 96px;
+  }
+
+  .postmatch-mvp-name {
+    font-size: 17px;
+  }
+
+  .postmatch-header {
+    padding: 10px 12px 4px 12px;
+  }
+
+  .postmatch-name {
+    font-size: 13px;
+  }
+
+  .postmatch-result {
+    font-size: 24px;
+  }
+
+  .postmatch-duration {
+    font-size: 15px;
+  }
+
+  .postmatch-badges {
+    padding: 8px 10px 4px 10px;
+  }
+
+  .postmatch-badges-side {
+    gap: 14px;
+  }
+
+  .postmatch-badge-art {
+    width: 42px;
+    height: 42px;
+  }
+
+  .postmatch-stat {
+    padding: 6px 12px 0 12px;
+  }
+
+  .postmatch-timeline {
+    height: 96px;
+  }
+
+  // Below roughly 30px a block cannot hold two digits; the widths still carry
+  // the shape, and the tooltip still carries the number.
+  .postmatch-life-block span {
+    display: none;
+  }
+}
+
+@media (max-width: 380px) {
+  .postmatch-mvp {
+    height: 78px;
+  }
+
+  .postmatch-mvp-name {
+    font-size: 15px;
+  }
+
+  .postmatch-badge-art {
+    width: 34px;
+    height: 34px;
+  }
+
+  .postmatch-badges-side {
+    gap: 10px;
+  }
+
+  .postmatch-stat-bar,
+  .postmatch-life-bar {
+    height: 18px;
+  }
+
+  .postmatch-timeline {
+    height: 78px;
+  }
+}
+
+// Short windows: the banner and timeline are the only blocks with height to
+// give back, and giving it keeps the stat bars on screen without scrolling.
+@media (max-height: 640px) {
+  .postmatch-mvp {
+    height: 88px;
+  }
+
+  .postmatch-timeline {
+    height: 88px;
+  }
+}
+
+@media (max-height: 460px) {
+  .postmatch-mvp {
+    height: 66px;
+  }
+
+  .postmatch-timeline {
+    height: 64px;
+  }
+
+  .postmatch-stat {
+    padding: 4px 12px 0 12px;
+  }
+}

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -246,7 +246,7 @@
 .postmatch-timeline {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 2px;
   height: 128px;
   padding: 0 2px;
@@ -266,10 +266,6 @@
   position: relative;
   flex: 1;
   min-width: 2px;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 
   &.turn-start::before {
     content: "";
@@ -282,21 +278,30 @@
   }
 }
 
+// Each bar grows away from the centre line: the player's upward, the
+// opponent's downward, so the two never overlap on the same column.
+//
+// Anchored with top/bottom rather than flex alignment, because a percentage
+// *margin* resolves against the containing block's width, not its height — a
+// `margin-bottom: 50%` here came out as half the column's ~10px width instead
+// of half its 128px height, and the centre line landed nowhere near the
+// middle. `top`/`bottom` percentages do resolve against height.
+//
+// The inline height is already halved to a share of the column, so a maximum
+// bar reaches the top or bottom edge exactly.
 .postmatch-timeline-bar {
-  width: 100%;
+  position: absolute;
+  left: 0;
+  right: 0;
   border-radius: 2px;
 
-  // Each bar grows away from the centre line: the player's upward, the
-  // opponent's downward, so the two never overlap on the same column.
   &.player {
-    align-self: flex-end;
-    margin-bottom: 50%;
+    bottom: 50%;
     background: linear-gradient(to top, #7d94bd, var(--color-u));
   }
 
   &.opp {
-    align-self: flex-start;
-    margin-top: 50%;
+    top: 50%;
     background: linear-gradient(to bottom, #c76a4c, var(--color-r));
   }
 }

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -184,6 +184,10 @@
   border-radius: 4px;
   overflow: hidden;
   background: var(--color-section);
+  // The seam where the two colours meet, matching the life-remaining blocks.
+  // A gap rather than a border so it sits in the same place whatever the
+  // split is — including 0, where a border would cling to the far edge.
+  gap: 1px;
 }
 
 .postmatch-stat-fill {
@@ -247,7 +251,6 @@
   height: 128px;
   padding: 0 2px;
   border-radius: 4px;
-  background: rgba(0, 0, 0, 0.35);
 }
 
 .postmatch-timeline-axis {

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -1,0 +1,299 @@
+// The post-match overview window. Transparent frame, one translucent card —
+// the overlay look, but focusable, because this one is meant to be used.
+
+.postmatch-root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: transparent;
+}
+
+.postmatch-panel {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin: 8px;
+  padding: 0 0 16px 0;
+  border-radius: 10px;
+  background: rgba(20, 21, 22, 0.88);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+  color: var(--color-text);
+}
+
+.postmatch-empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--color-text-dark);
+}
+
+.postmatch-dim {
+  color: var(--color-text-dark);
+  font-size: 13px;
+}
+
+// --- MVP banner ------------------------------------------------------------
+
+.postmatch-mvp {
+  height: 132px;
+  background-size: cover;
+  background-position: center 28%;
+  border-radius: 10px 10px 0 0;
+  display: flex;
+  align-items: flex-end;
+}
+
+.postmatch-mvp-shade {
+  width: 100%;
+  padding: 10px 16px 12px 16px;
+  border-radius: 0 0 0 0;
+  background: linear-gradient(
+    to top,
+    rgba(10, 10, 11, 0.94) 0%,
+    rgba(10, 10, 11, 0.72) 45%,
+    rgba(10, 10, 11, 0) 100%
+  );
+}
+
+.postmatch-mvp-label {
+  font-size: 11px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--color-m);
+}
+
+.postmatch-mvp-name {
+  font-family: var(--main-font-name);
+  font-size: 22px;
+  color: var(--color-text-hover);
+}
+
+.postmatch-mvp-sub {
+  font-size: 12px;
+  color: var(--color-text-dark);
+}
+
+// --- header ----------------------------------------------------------------
+
+.postmatch-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px 6px 20px;
+}
+
+.postmatch-player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 34%;
+}
+
+.postmatch-name {
+  font-family: var(--main-font-name);
+  font-size: 15px;
+  color: var(--color-text-hover);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.postmatch-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.postmatch-result {
+  font-family: var(--main-font-name);
+  font-size: 30px;
+  line-height: 1.1;
+
+  &.won { color: var(--color-g); }
+  &.lost { color: var(--color-r); }
+}
+
+.postmatch-duration {
+  font-size: 17px;
+  color: var(--color-text);
+}
+
+// --- best-card badges ------------------------------------------------------
+
+.postmatch-badges {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 10px 16px 6px 16px;
+}
+
+.postmatch-badges-side {
+  display: flex;
+  gap: 22px;
+  width: 45%;
+  justify-content: center;
+}
+
+.postmatch-badges-sep {
+  width: 1px;
+  align-self: stretch;
+  background: var(--color-line-sep);
+}
+
+.postmatch-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+}
+
+.postmatch-badge-label {
+  font-size: 12px;
+  color: var(--color-text-dark);
+}
+
+.postmatch-badge-art {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--color-section);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+// --- stat bars -------------------------------------------------------------
+
+.postmatch-stat {
+  padding: 8px 20px 0 20px;
+}
+
+.postmatch-stat-title {
+  text-align: center;
+  font-size: 13px;
+  color: var(--color-text);
+  margin-bottom: 5px;
+}
+
+.postmatch-stat-bar,
+.postmatch-life-bar {
+  display: flex;
+  height: 22px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--color-section);
+}
+
+.postmatch-stat-fill {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  transition: width 0.35s ease-out;
+
+  &.player {
+    justify-content: flex-start;
+    background: linear-gradient(to right, #7d94bd, var(--color-u));
+  }
+
+  &.opp {
+    justify-content: flex-end;
+    background: linear-gradient(to left, #c76a4c, var(--color-r));
+  }
+}
+
+.postmatch-stat-value {
+  font-size: 12px;
+  color: #14151a;
+  padding: 0 7px;
+}
+
+// --- life remaining --------------------------------------------------------
+
+.postmatch-life-bar {
+  gap: 1px;
+  background: transparent;
+}
+
+.postmatch-life-block {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  color: #14151a;
+
+  &.player { background: var(--color-u); }
+  &.opp { background: var(--color-r); }
+
+  // Blocks get narrow fast in a long game; the number is a bonus, not the
+  // point, so let it disappear rather than overflow the block.
+  span {
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+  }
+}
+
+// --- timeline --------------------------------------------------------------
+
+.postmatch-timeline {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 128px;
+  padding: 0 2px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.postmatch-timeline-axis {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: var(--color-line-sep);
+}
+
+.postmatch-timeline-col {
+  position: relative;
+  flex: 1;
+  min-width: 2px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  &.turn-start::before {
+    content: "";
+    position: absolute;
+    left: -1.5px;
+    top: 8%;
+    bottom: 8%;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.07);
+  }
+}
+
+.postmatch-timeline-bar {
+  width: 100%;
+  border-radius: 2px;
+
+  // Each bar grows away from the centre line: the player's upward, the
+  // opponent's downward, so the two never overlap on the same column.
+  &.player {
+    align-self: flex-end;
+    margin-bottom: 50%;
+    background: linear-gradient(to top, #7d94bd, var(--color-u));
+  }
+
+  &.opp {
+    align-self: flex-start;
+    margin-top: 50%;
+    background: linear-gradient(to bottom, #c76a4c, var(--color-r));
+  }
+}

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -7,6 +7,50 @@
   height: 100vh;
   overflow: hidden;
   background: transparent;
+  position: relative;
+}
+
+// Frameless (transparent) mode: the card is the window, so it is also the
+// thing you drag it by. The wheel still scrolls; only click-dragging inside
+// the panel moves the window instead of selecting text, which is the trade a
+// title-bar-less overlay makes everywhere else in the app too.
+.postmatch-root.frameless .postmatch-panel {
+  -webkit-app-region: drag;
+}
+
+.postmatch-close {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  z-index: 5;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  // Never part of the drag handle, or it could not be clicked.
+  -webkit-app-region: no-drag;
+  // The banner art behind it is arbitrary, so the button carries its own
+  // backing rather than relying on contrast that may not be there.
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  transition: background 0.15s ease-out;
+
+  &:hover {
+    background: var(--color-r);
+  }
+
+  svg {
+    width: 10px;
+    height: 10px;
+    fill: var(--color-text);
+  }
+
+  &.mac svg {
+    width: 12px;
+    height: 12px;
+  }
 }
 
 .postmatch-panel {
@@ -17,7 +61,10 @@
   padding: 0 0 16px 0;
   border-radius: 10px;
   background: rgba(20, 21, 22, 0.88);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+  // Must fit inside the 8px margin: offset + blur is the reach, and anything
+  // past it lands on the transparent window as a dark halo tracing the panel —
+  // the same false frame the native shadow was drawing. 2 + 6 = 8.
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   color: var(--color-text);
 }
 

--- a/src/scss/postMatch.scss
+++ b/src/scss/postMatch.scss
@@ -19,7 +19,10 @@
 }
 
 .postmatch-close {
-  position: absolute;
+  // Fixed, not absolute: it sits inside the scrolling panel (it must be a
+  // descendant of the drag region for no-drag to take effect) but should stay
+  // pinned to the corner rather than scroll away with the content.
+  position: fixed;
   top: 16px;
   right: 18px;
   z-index: 5;

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -6,6 +6,8 @@ export const WINDOW_MAIN = "MTG Arena Tool";
 
 export const WINDOW_UPDATER = "mtgatool-updater";
 
+export const WINDOW_POSTMATCH = "mtgatool-postmatch";
+
 export const WINDOW_OVERLAY_0 = "mtgatool-overlay-0";
 
 export const WINDOW_OVERLAY_1 = "mtgatool-overlay-1";

--- a/src/types/localSettings.ts
+++ b/src/types/localSettings.ts
@@ -26,6 +26,7 @@ export const settingKeys = [
   "pubkey",
   "importLogHistory",
   "whatsNewSeen",
+  "postMatchOverview",
 ] as const;
 
 export type SettingKey = typeof settingKeys[number];
@@ -54,4 +55,10 @@ export const defaultSettings: Record<SettingKey, string> = {
   importLogHistory: "false",
   // The app version whose "What's new" the user has already dismissed.
   whatsNewSeen: "",
+  // The match the post-match overview window should render. Handed over here
+  // rather than broadcast, because the window is created in response to the
+  // same event that carries the data — it would still be booting when a
+  // message went out, and would miss it. localStorage is shared across every
+  // window of the app, so the overview reads this the moment it mounts.
+  postMatchOverview: "",
 };

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -38,9 +38,34 @@ export interface InternalPlayer {
   leaderboardPlace?: number;
 }
 
+export interface MatchPlayerStats {
+  lifeGained: number;
+  lifeLost: number;
+  manaUsed: number;
+  /** grpId -> total damage dealt by that card. */
+  damage: Record<string, number>;
+  /** One entry per life change, in order — the "life remaining" blocks. */
+  lifeTotals: number[];
+}
+
+/**
+ * The end-of-match summary, for the post-match overview.
+ *
+ * Optional because it is only written from the version that started recording
+ * it: every match saved before then has none, and the overview hides whatever
+ * is missing rather than drawing empty bars.
+ */
+export interface MatchPostStats {
+  statsHeatMap: Heat[];
+  totalTurns: number;
+  playerStats: MatchPlayerStats;
+  oppStats: MatchPlayerStats;
+}
+
 export interface InternalMatch {
   draws: number;
   arenaId: string;
+  postStats?: MatchPostStats;
   playerDeck: InternalDeck;
   oppDeck: InternalDeck;
   date: string;


### PR DESCRIPTION
Resurrects the post-match review screen from the pre-rewrite app, and fixes a GRE parser bug that surfaced while building it.

## The overview

A window that opens when a match ends, showing how the game actually went: result, both ranks, duration, the best cards on each side, and life/mana/activity totals.

It is gated on the **"Show post-match overview"** toggle that has been sitting in Settings, defaulted to on and wired to nothing, since the rewrite — this is the screen it used to control.

Built like the overlays (transparent frame, translucent panel, pinned window title) with the differences a window meant to be *used* needs: it stays focusable so the close button works, and it is centred rather than always-on-top. With transparency off it keeps a normal title bar, which is also the fallback for setups where a transparent frameless window cannot be interacted with.

Beyond the original:

- the card that dealt the most damage on either side headlines the screen as the match MVP, in its own art
- the timeline is a mirrored chart with turn separators and per-phase tooltips
- life-remaining blocks are sized by the life they record, each side owning half the bar so the seam stays centred
- the layout adapts down to a 320x380 floor

Shown for bot matches too — those are never written to the database, but the window reads the match it is handed.

## The data behind it

Almost all of it was already being computed each match and thrown away. Two things stopped it being usable:

- **`setHeat` had no call sites.** The timeline accumulator was fully written, coalescing included, and never once invoked. That is now wired to the points where a player acts.
- **Nothing was persisted.** The block writing `postStats` into the saved match was commented out.

`postStats` is optional, so matches saved before this have none and the overview drops what is missing rather than drawing empty bars.

## The GRE bug this uncovered

The parser treated any message id below the highest seen as "the numbering restarted, this is a new game" and reset the per-game state — **65 times in one observed match**.

Each reset wiped `cardsCast`, `handsDrawn`, `players`, `currentPriority` and the priority timers, which is the whole of:

- match duration reading `0:01`
- cards cast reading `0`
- the missing per-player Cast cards
- **empty opening hands in the existing history view**

It also cleared `processedAnnotations`, the guard against handling an annotation twice, so re-delivered annotations were counted again — life totals arrived in triplicate and "life lost" reached 87 in a game of 20.

The GRE resolves a whole state server-side and emits its conclusion before the events that produced it, so out-of-order delivery is normal. A low id means either a genuinely late event (the message carrying the killing blow) or a re-delivery, and a high-water comparison cannot separate them — it discards the late events along with the repeats. The ids actually handled are now tracked, so a repeat is skipped and a late arrival is processed however far below the mark it sits.

Only accumulating work is skipped for a repeat. `gameInfo` and `players` are read from every message since they assign current truth, and the opening-hand check runs for repeats too — it is the re-delivery that often carries the zones needed to resolve the hand.

## Verification

- New replay test over the recorded log, which is what a dead accumulator needs: `postStats.spec.js`
- Verified on live matches: duration 337s, 23 casts, 2 opening hands, life totals `[18,17,15,13,11,10,0]` with no repeats, life lost 25 against a 20-life start ending at -5, and the lethal hit present in the action log
- 27/27 tests pass

## Not included

The overlays have the same native-shadow border; left untouched deliberately.