### PR TITLE
Make overlay windows lighter on memory

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,4 +1,6 @@
 
+const path = require("path");
+
 const WebpackReactComponentNamePlugin = require("webpack-react-component-name");
 const ModuleReplacement = require("./module-resolver-file");
 const eslintConfig = require("./.eslintrc");
@@ -6,31 +8,84 @@ const supabaseCjsAlias = require("./supabaseCjsAlias");
 
 process.env.GENERATE_SOURCEMAP = true;
 
+/**
+ * A second entry + HTML for the "look past the game" windows.
+ *
+ * The card hover, match overlays and post-match overview load `overlay.html`
+ * (entry `src/overlayIndex.tsx`) instead of `index.html`. That entry imports
+ * only those three component trees, so webpack keeps the whole main-app graph —
+ * App and its views, the router, the log watcher / GRE parser, the memory
+ * reader, the cloud sync — out of the chunks this HTML loads. Each of these
+ * windows is its own Chromium renderer, and this is what stops every one of
+ * them paying the memory cost of code it never runs.
+ *
+ * Uses entry-point-based chunk selection (`chunks: ['main' | 'overlay']`), so
+ * each HTML gets its own entry, its runtime, and only the shared/vendor chunks
+ * that entry actually uses — main-only vendor code never reaches overlay.html.
+ */
+function addOverlayEntry(webpackConfig) {
+  const overlayEntry = path.resolve(__dirname, "src/overlayIndex.tsx");
+  webpackConfig.entry = {
+    main: webpackConfig.entry,
+    overlay: overlayEntry,
+  };
+
+  // Dev output is `static/js/bundle.js` with no [name], which two entries would
+  // collide on; production already carries [name]. Only rewrite when missing.
+  if (
+    webpackConfig.output &&
+    typeof webpackConfig.output.filename === "string" &&
+    !webpackConfig.output.filename.includes("[name]")
+  ) {
+    webpackConfig.output.filename = "static/js/[name].bundle.js";
+  }
+
+  const mainHtml = webpackConfig.plugins.find(
+    (p) => p.constructor && p.constructor.name === "HtmlWebpackPlugin"
+  );
+  if (!mainHtml) {
+    throw new Error("craco: HtmlWebpackPlugin not found — CRA config changed?");
+  }
+  // Restrict index.html to the main entry, then mint a sibling for overlay.html
+  // from the same options (template aside) so minify/inject/inline-runtime all
+  // match. Same constructor, so the InlineChunkHtmlPlugin hooks both.
+  const HtmlWebpackPlugin = mainHtml.constructor;
+  const mainHtmlOptions = mainHtml.userOptions || mainHtml.options;
+
+  webpackConfig.plugins.push(
+    new HtmlWebpackPlugin({
+      ...mainHtmlOptions,
+      filename: "overlay.html",
+      template: path.resolve(__dirname, "public/overlay.html"),
+      chunks: ["overlay"],
+    })
+  );
+  mainHtml.options.chunks = ["main"];
+  if (mainHtml.userOptions) mainHtml.userOptions.chunks = ["main"];
+
+  return webpackConfig;
+}
+
 // https://www.npmjs.com/package/@craco/craco
 module.exports = {
   webpack: {
-    configure: {
-      target: "electron-renderer",
-      module: {
-        rules: [
-          {
-            test: /\.node$/,
-            use: "native-addon-loader",
-          },
-        ],
-      },
-      node: {
-        fs: "empty",
-      },
+    configure: (webpackConfig) => {
+      webpackConfig.target = "electron-renderer";
+      webpackConfig.module.rules.push({
+        test: /\.node$/,
+        use: "native-addon-loader",
+      });
+      webpackConfig.node = { ...webpackConfig.node, fs: "empty" };
       // Force every @supabase/* package onto its CommonJS build. supabase-js v2
       // ships .mjs re-exports that webpack 4 (react-scripts 4) can't analyze
       // ("Attempted import error: createClient is not exported"). See
       // supabaseCjsAlias.js.
-      resolve: {
-        alias: {
-          ...supabaseCjsAlias(),
-        },
-      },
+      webpackConfig.resolve.alias = {
+        ...webpackConfig.resolve.alias,
+        ...supabaseCjsAlias(),
+      };
+
+      return addOverlayEntry(webpackConfig);
     },
     plugins: [
       ...ModuleReplacement({ webIndex: false, electronIndex: true }),

--- a/public/electron.js
+++ b/public/electron.js
@@ -21,7 +21,6 @@ let tray = null;
 
 app.disableHardwareAcceleration();
 app.setAppUserModelId("com.mtgatool.desktop");
-app.allowRendererProcessReuse = false;
 
 // The hidden "mtgatool-background" window hosts the log watcher AND the
 // Supabase Realtime socket for live overlay sharing. Chromium aggressively
@@ -144,13 +143,16 @@ function createCardHoverWindow() {
   );
 
   mainGlobals.cardHoverWindow.removeMenu();
+  // The slim overlay bundle (src/overlayIndex.tsx), not the full app — see
+  // craco.config.js. The hover window only ever shows a card image.
   mainGlobals.cardHoverWindow.loadURL(
-    process.env.ELECTRON_START_URL ||
-      url.format({
-        pathname: path.join(__dirname, "..", "build", "index.html"),
-        protocol: "file:",
-        slashes: true,
-      })
+    process.env.ELECTRON_START_URL
+      ? `${process.env.ELECTRON_START_URL}/overlay.html`
+      : url.format({
+          pathname: path.join(__dirname, "..", "build", "overlay.html"),
+          protocol: "file:",
+          slashes: true,
+        })
   );
 
   mainGlobals.cardHoverWindow.once("dom-ready", () => {

--- a/public/overlay.html
+++ b/public/overlay.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <base href="./">
+    <link rel="icon" href="%PUBLIC_URL%/icons/icon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/icons/icon-256.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/broadcastChannel/channelMessages.ts
+++ b/src/broadcastChannel/channelMessages.ts
@@ -42,7 +42,9 @@ export type MessageType =
   | "DRAFT_VOTES"
   | "DRAFT_END"
   | "UPDATE_ACTIVE_EVENTS"
-  | "DAEMON_GET_PLAYER_ID";
+  | "DAEMON_GET_PLAYER_ID"
+  | "CARDS_DB_REQUEST"
+  | "CARDS_DB_RESPONSE";
 
 /** One timed memory read, from the background window to whoever is showing it. */
 export interface ReaderReadMessage {
@@ -213,6 +215,39 @@ export interface DaemonGetPlayerId extends ChannelMessageBase {
   type: "DAEMON_GET_PLAYER_ID";
 }
 
+/** Shape of a card-db query result, mirrored here to avoid an import cycle. */
+export interface CardsDbQueryResult {
+  columns: string[];
+  values: unknown[][];
+}
+
+/**
+ * A card-db query from a proxy window (overlay / hover / post-match) to the
+ * window that owns the SQLite worker. `from` names the requester so the single
+ * broadcast reply reaches only it; `rid` is unique within that window.
+ */
+export interface CardsDbRequestMessage extends ChannelMessageBase {
+  type: "CARDS_DB_REQUEST";
+  value: {
+    from: string;
+    rid: number;
+    sql: string;
+    params: unknown[];
+  };
+}
+
+/** The answer to a CARDS_DB_REQUEST, addressed back to `to` (the requester). */
+export interface CardsDbResponseMessage extends ChannelMessageBase {
+  type: "CARDS_DB_RESPONSE";
+  value: {
+    to: string;
+    rid: number;
+    ok: boolean;
+    result?: CardsDbQueryResult;
+    error?: string;
+  };
+}
+
 export type ChannelMessage =
   | ReaderReadMessage
   | PopupMessage
@@ -244,4 +279,6 @@ export type ChannelMessage =
   | DraftVotesMessage
   | DraftEndMessage
   | UpdateActiveEventsMessage
-  | DaemonGetPlayerId;
+  | DaemonGetPlayerId
+  | CardsDbRequestMessage
+  | CardsDbResponseMessage;

--- a/src/electronIndex.tsx
+++ b/src/electronIndex.tsx
@@ -60,6 +60,9 @@ if (title == WINDOW_UPDATER) {
     module.hot.accept();
   }
   backgroundChannelListeners();
+  // This window owns the SQLite worker; answer proxy windows (overlays, hover,
+  // post-match) so they don't each load their own 17MB copy of the database.
+  cardsDb.serveRemoteRequests();
 } else if (title == WINDOW_HOVER) {
   defaultLocalSettings();
   ReactDOM.render(

--- a/src/overlay/createOverlay.ts
+++ b/src/overlay/createOverlay.ts
@@ -68,6 +68,8 @@ export default function createOverlay(
   });
 
   const proc: any = process;
+  // The slim overlay bundle (src/overlayIndex.tsx), not the full app — see
+  // craco.config.js. Keeps the main-app graph out of this renderer's memory.
   newWindow.loadURL(
     remote.app.isPackaged
       ? url.format({
@@ -75,12 +77,12 @@ export default function createOverlay(
             proc.resourcesPath,
             "app.asar",
             "build",
-            "index.html"
+            "overlay.html"
           ),
           protocol: "file:",
           slashes: true,
         })
-      : "http://localhost:3001"
+      : "http://localhost:3001/overlay.html"
   );
 
   remote.require("@electron/remote/main").enable(newWindow.webContents);

--- a/src/overlayIndex.tsx
+++ b/src/overlayIndex.tsx
@@ -1,0 +1,65 @@
+/**
+ * Slim entry for the "look past the game" windows: card hover, the match
+ * overlays and the post-match overview.
+ *
+ * These windows load `overlay.html`, not `index.html`, so their renderer never
+ * pulls in the main-app graph — App and its views, the router, the log watcher
+ * and GRE parser (`backgroundChannelListeners`), the memory reader, the cloud
+ * sync in `mainChannelListeners`, the updater. That whole tree is reachable
+ * only from `electronIndex`, so webpack keeps it out of the chunks this HTML
+ * loads. The point is memory: each of these is a separate Chromium renderer,
+ * and an overlay has no use for any of it.
+ *
+ * Window role is still chosen by BrowserWindow title, exactly as in
+ * electronIndex — the difference is only which HTML/entry a window loads.
+ */
+import "./index.scss";
+
+// eslint-disable-next-line no-use-before-define
+import React from "react";
+import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+
+import Hover from "./hover";
+import Overlay from "./overlay";
+import PostMatch from "./postmatch";
+import reduxAction from "./redux/reduxAction";
+import store from "./redux/stores/rendererStore";
+import * as serviceWorker from "./serviceWorker";
+import { WINDOW_HOVER, WINDOW_POSTMATCH } from "./types/app";
+import cardsDb from "./utils/cardsDb/cardsDbClient";
+import defaultLocalSettings from "./utils/defaultLocalSettings";
+import getWindowTitle from "./utils/electron/getWindowTitle";
+
+const title = getWindowTitle();
+
+defaultLocalSettings();
+
+function windowFor(t: string): JSX.Element {
+  if (t === WINDOW_HOVER) return <Hover />;
+  if (t === WINDOW_POSTMATCH) return <PostMatch />;
+  // Anything else loading this HTML is one of the WINDOW_OVERLAY_<id> windows.
+  return <Overlay />;
+}
+
+ReactDOM.render(
+  <React.StrictMode>
+    <Provider store={store}>{windowFor(title)}</Provider>
+  </React.StrictMode>,
+  document.getElementById("root")
+);
+
+if (module.hot && process.env.NODE_ENV === "development") {
+  module.hot.accept();
+}
+
+// Proxy mode: overlay/hover/post-match windows don't own the SQLite worker,
+// they query the background window's over the broadcast channel — see
+// cardsDbClient. init() is still called so the eager lookup tables load.
+cardsDb.init().then((ready) => {
+  if (ready) {
+    reduxAction(store.dispatch, { type: "FORCE_COLLECTION", arg: undefined });
+  }
+});
+
+serviceWorker.unregister();

--- a/src/postmatch/createPostMatchWindow.ts
+++ b/src/postmatch/createPostMatchWindow.ts
@@ -98,6 +98,8 @@ export default function createPostMatchWindow(): void {
   });
 
   const proc: any = process;
+  // The slim overlay bundle (src/overlayIndex.tsx), not the full app — see
+  // craco.config.js.
   newWindow.loadURL(
     remote.app.isPackaged
       ? url.format({
@@ -105,12 +107,12 @@ export default function createPostMatchWindow(): void {
             proc.resourcesPath,
             "app.asar",
             "build",
-            "index.html"
+            "overlay.html"
           ),
           protocol: "file:",
           slashes: true,
         })
-      : "http://localhost:3001"
+      : "http://localhost:3001/overlay.html"
   );
 
   remote.require("@electron/remote/main").enable(newWindow.webContents);

--- a/src/utils/cardsDb/cardsDbClient.ts
+++ b/src/utils/cardsDb/cardsDbClient.ts
@@ -12,7 +12,19 @@
  * background window later, or swapping in a native driver under Electron, is a
  * change to this file and nothing above it.
  */
+import {
+  CardsDbRequestMessage,
+  CardsDbResponseMessage,
+  ChannelMessage,
+} from "../../broadcastChannel/channelMessages";
 import { CardSet, DbCardDataV2 } from "../../types";
+import {
+  WINDOW_BACKGROUND,
+  WINDOW_MAIN,
+  WINDOW_UPDATER,
+} from "../../types/app";
+import bcConnect from "../bcConnect";
+import getWindowTitle from "../electron/getWindowTitle";
 import loadCardsDbBytes from "./loadCardsDbBytes";
 import rowToCard, { CARD_COLUMNS } from "./rowToCard";
 
@@ -39,6 +51,23 @@ class CardsDbClient {
   private pending = new Map<number, Pending>();
 
   private nextId = 1;
+
+  /**
+   * Proxy mode. Overlay, hover and post-match windows do not own a worker:
+   * loading a second ~17MB SQLite image into each of them is what made every
+   * overlay cost as much RAM as the main window. Instead they forward queries
+   * over the broadcast channel to the window that does own one (the background
+   * window, which is always alive), and this whole client behaves as a thin
+   * RPC — `query()` is the only method that touches the worker, so everything
+   * built on it (cards, abilities, lookups) rides along unchanged.
+   */
+  private remote = false;
+
+  private remoteChannel: BroadcastChannel | null = null;
+
+  private remoteClientId = "";
+
+  private serving = false;
 
   private readyPromise: Promise<boolean> | null = null;
 
@@ -160,7 +189,131 @@ class CardsDbClient {
   public init(): Promise<boolean> {
     if (this.readyPromise) return this.readyPromise;
 
-    this.readyPromise = (async () => {
+    const title = getWindowTitle();
+    this.remote =
+      title !== WINDOW_MAIN &&
+      title !== WINDOW_BACKGROUND &&
+      title !== WINDOW_UPDATER;
+
+    this.readyPromise = this.remote ? this.initRemote() : this.initLocal();
+    return this.readyPromise;
+  }
+
+  /**
+   * Proxy init: no worker, no 17MB image. Wire the channel first, then pull the
+   * same small lookup tables the local path does — they go through `query()`,
+   * which is now an RPC, so the owner answers them.
+   */
+  private async initRemote(): Promise<boolean> {
+    try {
+      this.remoteClientId = getWindowTitle();
+      const channel = bcConnect() as BroadcastChannel;
+      this.remoteChannel = channel;
+      channel.addEventListener("message", this.handleRemoteResponse);
+
+      await this.loadLookups();
+
+      this.ready = true;
+      this.source = "remote";
+      // eslint-disable-next-line no-console
+      console.log("[cards-db] ready (proxy) via broadcast channel");
+      this.readyListeners.forEach((fn) => fn());
+      return true;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log("[cards-db] proxy init failed", e);
+      this.ready = false;
+      this.readyListeners.forEach((fn) => fn());
+      return false;
+    }
+  }
+
+  private handleRemoteResponse = (e: MessageEvent): void => {
+    const data = e.data as ChannelMessage | undefined;
+    if (!data || data.type !== "CARDS_DB_RESPONSE") return;
+    const { to, rid, ok, result, error } = (data as CardsDbResponseMessage)
+      .value;
+    if (to !== this.remoteClientId) return;
+    const entry = this.pending.get(rid);
+    if (!entry) return;
+    this.pending.delete(rid);
+    if (ok) entry.resolve(result);
+    else entry.reject(new Error(error));
+  };
+
+  private remoteQuery(sql: string, params: unknown[]): Promise<QueryResult> {
+    const channel = this.remoteChannel;
+    if (!channel) {
+      return Promise.reject(new Error("cards-db proxy channel not ready"));
+    }
+    const rid = this.nextId;
+    this.nextId += 1;
+    return new Promise<QueryResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (this.pending.delete(rid)) {
+          reject(new Error("cards-db proxy query timed out"));
+        }
+      }, 15000);
+      this.pending.set(rid, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timeout);
+          reject(err);
+        },
+      });
+      const msg: CardsDbRequestMessage = {
+        type: "CARDS_DB_REQUEST",
+        value: { from: this.remoteClientId, rid, sql, params },
+      };
+      channel.postMessage(msg);
+    });
+  }
+
+  /**
+   * Answer proxy windows' queries against this window's worker. Called once in
+   * the background window (the owner), it listens on the same channel the rest
+   * of the app uses — `addEventListener`, so it coexists with the window's
+   * existing `onmessage` handler rather than replacing it.
+   */
+  public serveRemoteRequests(): void {
+    if (this.serving) return;
+    this.serving = true;
+    const channel = bcConnect() as BroadcastChannel;
+    channel.addEventListener("message", async (e: MessageEvent) => {
+      const data = e.data as ChannelMessage | undefined;
+      if (!data || data.type !== "CARDS_DB_REQUEST") return;
+      const { from, rid, sql, params } = (data as CardsDbRequestMessage).value;
+      let response: CardsDbResponseMessage;
+      try {
+        // Idempotent, and guarantees the worker is up before the first query
+        // an overlay fires on open.
+        await this.init();
+        const result = await this.query(sql, params);
+        response = {
+          type: "CARDS_DB_RESPONSE",
+          value: { to: from, rid, ok: true, result },
+        };
+      } catch (err: any) {
+        response = {
+          type: "CARDS_DB_RESPONSE",
+          value: {
+            to: from,
+            rid,
+            ok: false,
+            error: String(err && err.message ? err.message : err),
+          },
+        };
+      }
+      channel.postMessage(response);
+    });
+  }
+
+  /** Worker init: owns the SQLite image. Used by the main and background windows. */
+  private initLocal(): Promise<boolean> {
+    return (async () => {
       const bytes = await loadCardsDbBytes();
       if (!bytes) return false;
 
@@ -214,8 +367,6 @@ class CardsDbClient {
         return false;
       }
     })();
-
-    return this.readyPromise;
   }
 
   /**
@@ -258,6 +409,7 @@ class CardsDbClient {
   }
 
   public query(sql: string, params: unknown[] = []): Promise<QueryResult> {
+    if (this.remote) return this.remoteQuery(sql, params);
     return this.post({ type: "query", sql, params });
   }
 
@@ -269,6 +421,10 @@ class CardsDbClient {
     cards: Record<string, number>,
     prevCards: Record<string, number>
   ): Promise<number> {
+    // Proxy windows don't own the collection table and never display owned /
+    // acquired counts, so there is nothing to set — the owner holds it. Only
+    // the main window (ContentWrapper) calls this in practice.
+    if (this.remote) return Promise.resolve(0);
     return this.post({ type: "setCollection", cards, prevCards });
   }
 

--- a/src/utils/cardsDb/cardsDbClient.ts
+++ b/src/utils/cardsDb/cardsDbClient.ts
@@ -211,6 +211,15 @@ class CardsDbClient {
       this.remoteChannel = channel;
       channel.addEventListener("message", this.handleRemoteResponse);
 
+      // The owner (background window) may not be answering yet: it loads the
+      // full app bundle and a 17MB database, while these proxy windows boot
+      // from a slim bundle and get here first. A lookup query fired now would
+      // hit a channel no one is listening on, time out, and — because init()
+      // memoises its result — leave the proxy permanently broken. So ping until
+      // the owner answers before doing anything that has to succeed.
+      const ownerUp = await this.waitForOwner();
+      if (!ownerUp) throw new Error("cards-db owner never answered");
+
       await this.loadLookups();
 
       this.ready = true;
@@ -221,11 +230,33 @@ class CardsDbClient {
       return true;
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.log("[cards-db] proxy init failed", e);
+      console.log("[cards-db] proxy init failed, will retry on demand", e);
       this.ready = false;
+      // Do not cache the failure: a later card() call re-runs init(), by which
+      // time the owner is up. Without this the first miss is forever.
+      this.readyPromise = null;
       this.readyListeners.forEach((fn) => fn());
       return false;
     }
+  }
+
+  /**
+   * Poll the owner with a cheap query until it answers. Each ping has a short
+   * timeout so a not-yet-listening owner is detected quickly and retried,
+   * rather than waiting out the full query timeout once.
+   */
+  private async waitForOwner(): Promise<boolean> {
+    const attempts = 60;
+    for (let i = 0; i < attempts; i += 1) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await this.remoteQuery("SELECT 1", [], 1000);
+        return true;
+      } catch {
+        // Not answering yet — the loop is the wait.
+      }
+    }
+    return false;
   }
 
   private handleRemoteResponse = (e: MessageEvent): void => {
@@ -241,7 +272,11 @@ class CardsDbClient {
     else entry.reject(new Error(error));
   };
 
-  private remoteQuery(sql: string, params: unknown[]): Promise<QueryResult> {
+  private remoteQuery(
+    sql: string,
+    params: unknown[],
+    timeoutMs = 15000
+  ): Promise<QueryResult> {
     const channel = this.remoteChannel;
     if (!channel) {
       return Promise.reject(new Error("cards-db proxy channel not ready"));
@@ -253,7 +288,7 @@ class CardsDbClient {
         if (this.pending.delete(rid)) {
           reject(new Error("cards-db proxy query timed out"));
         }
-      }, 15000);
+      }, timeoutMs);
       this.pending.set(rid, {
         resolve: (value) => {
           clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Reduces the memory each overlay window costs. An overlay was using roughly as much RAM as the main window (~140MB) because every overlay/hover/post-match window (a) loaded its own ~17MB SQLite card database into a worker, and (b) loaded the entire app bundle even though it renders a small overlay. There can be up to five overlays open at once.

Two independent changes, one per commit:

- **Proxy overlay card lookups to the background window's database.** Overlay/hover/post-match windows no longer own a SQLite worker. `cardsDbClient` runs in a proxy mode where `query()` is forwarded over the existing `BroadcastChannel` to the window that owns a worker (the background window, always alive), which answers via `serveRemoteRequests()`. Every card/ability/lookup already funnels through `query()`, so this one change carries the whole client across unchanged. Verified live: a proxy window (`hasWorker:false`) fetched real cards over the channel; per-window private memory dropped ~40MB.

- **Load overlays from a slim bundle instead of the whole app.** These windows now load a separate `overlay.html` (entry `src/overlayIndex.tsx`) that imports only the overlay/hover/post-match trees, so webpack keeps the main-app graph — App and its views, the router, the log watcher / GRE parser, the memory reader, the cloud sync — out of the chunks this HTML loads. A production build confirms `overlay.html` pulls its 52KB overlay chunk + the shared vendor chunk, and excludes the 378KB main chunk and the 286KB main-only vendor chunk. Also removes the dead `app.allowRendererProcessReuse = false` line (no effect since Electron 12, and it never governed multi-window process sharing).

## Test plan

- [x] `tsc --noEmit` and eslint pass on changed files
- [x] Production `react-build` compiles; `overlay.html` emitted with only the overlay + shared chunks
- [x] Live Electron: background owns worker + serves; hover/proxy has no worker yet resolves real cards via the channel
- [x] In a live match, confirm the `mtgatool-overlay-*` windows render decklists/odds/log correctly and measure per-overlay memory
- [x] Confirm post-match overview window still renders
- [x] Sanity-check a packaged build loads `overlay.html` from `app.asar`
