### PR TITLE
Restore draft tracking: 2026 log format, replay, cloud sync, live overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "lodash": "^4.17.21",
         "match-sorter": "^6.3.0",
         "mathjs": "^9.3.0",
-        "mtga-reader": "^0.1.9",
+        "mtga-reader": "^0.1.10",
         "mtgatool-shared": "^2.2.0",
         "nan": "^2.20.0",
         "proto2typescript": "^2.2.0",
@@ -19439,9 +19439,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mtga-reader": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.9.tgz",
-      "integrity": "sha512-zNEOEMRuuGy/WU9/y9GaIKVVvqxa7nGSfteuPL/N9i94XITamLMWKMhnGpDn+tERrNk2fHhTmB03rLjbgqZTiw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.10.tgz",
+      "integrity": "sha512-W/NRrgKTSRC3hSdZPWn/GWqmN+pyfKIt6GJh6qscLgh/2MfbmsT3IfCSyIf7XXENtHBVBfs3gzyv6tYnIZCjRQ==",
       "license": "GPL-3.0-only",
       "engines": {
         "node": ">= 16"
@@ -45368,9 +45368,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mtga-reader": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.9.tgz",
-      "integrity": "sha512-zNEOEMRuuGy/WU9/y9GaIKVVvqxa7nGSfteuPL/N9i94XITamLMWKMhnGpDn+tERrNk2fHhTmB03rLjbgqZTiw=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.10.tgz",
+      "integrity": "sha512-W/NRrgKTSRC3hSdZPWn/GWqmN+pyfKIt6GJh6qscLgh/2MfbmsT3IfCSyIf7XXENtHBVBfs3gzyv6tYnIZCjRQ=="
     },
     "mtgatool-shared": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.21",
     "match-sorter": "^6.3.0",
     "mathjs": "^9.3.0",
-    "mtga-reader": "^0.1.9",
+    "mtga-reader": "^0.1.10",
     "mtgatool-shared": "^2.2.0",
     "nan": "^2.20.0",
     "proto2typescript": "^2.2.0",

--- a/src/background/__tests__/draftParsing.spec.ts
+++ b/src/background/__tests__/draftParsing.spec.ts
@@ -249,3 +249,64 @@ describe("bot draft in the 2026 log format", () => {
     expect(course.CurrentLosses).toBe(1);
   });
 });
+
+describe("human draft in the 2026 log format", () => {
+  const HUMAN_EVENT = "PremierDraft_TST_20990101";
+  const HUMAN_DRAFT_ID = "cccccccc-0000-4000-8000-0000000000c1";
+
+  const HUMAN_FIXTURE = [
+    req("EventJoin", { EventName: HUMAN_EVENT }),
+    res("EventJoin", {
+      Course: {
+        CourseId: HUMAN_DRAFT_ID,
+        InternalEventName: HUMAN_EVENT,
+        CurrentModule: "PairSealed",
+        ModulePayload: "",
+        CourseDeckSummary: { Attributes: [] },
+        CardPool: [],
+        CardStyles: [],
+      },
+      InventoryInfo: {},
+    }),
+    // Packs arrive as notifications (1-indexed, comma-joined string)...
+    `[UnityCrossThreadLogger]Draft.Notify {"draftId":"${HUMAN_DRAFT_ID}","SelfPick":1,"SelfPack":1,"PackCards":"910001,910002,910003"}\n`,
+    // ...and picks as EventPlayerDraftMakePick with a GrpIds array.
+    req("EventPlayerDraftMakePick", {
+      DraftId: HUMAN_DRAFT_ID,
+      GrpIds: [910002],
+      Pack: 1,
+      Pick: 1,
+    }),
+    res("EventPlayerDraftMakePick", { IsPickSuccessful: true }),
+    `[UnityCrossThreadLogger]Draft.Notify {"draftId":"${HUMAN_DRAFT_ID}","SelfPick":2,"SelfPack":1,"PackCards":"910004,910005"}\n`,
+    req("EventPlayerDraftMakePick", {
+      DraftId: HUMAN_DRAFT_ID,
+      GrpIds: [910005],
+      Pack: 1,
+      Pick: 2,
+    }),
+    res("EventPlayerDraftMakePick", { IsPickSuccessful: true }),
+  ].join("");
+
+  beforeAll(async () => {
+    await replay(HUMAN_FIXTURE);
+  });
+
+  it("tracks packs from Draft.Notify (1-indexed to 0-indexed)", () => {
+    expect(globalStore.currentDraft.packs[0][0]).toEqual([
+      910001, 910002, 910003,
+    ]);
+    expect(globalStore.currentDraft.packs[0][1]).toEqual([910004, 910005]);
+  });
+
+  it("tracks picks from the GrpIds array", () => {
+    expect(globalStore.currentDraft.picks[0][0]).toBe(910002);
+    expect(globalStore.currentDraft.picks[0][1]).toBe(910005);
+    expect(globalStore.currentDraft.pickedCards).toEqual([910002, 910005]);
+  });
+
+  it("identifies the draft by DraftId and event", () => {
+    expect(globalStore.currentDraft.id).toBe(HUMAN_DRAFT_ID);
+    expect(globalStore.currentDraft.eventId).toBe(HUMAN_EVENT);
+  });
+});

--- a/src/background/__tests__/draftParsing.spec.ts
+++ b/src/background/__tests__/draftParsing.spec.ts
@@ -286,6 +286,16 @@ describe("human draft in the 2026 log format", () => {
       Pick: 2,
     }),
     res("EventPlayerDraftMakePick", { IsPickSuccessful: true }),
+    // The 2026 completion response is the updated course, and it is the only
+    // end signal a human draft gets.
+    req("DraftCompleteDraft", { DraftId: HUMAN_DRAFT_ID }),
+    res("DraftCompleteDraft", {
+      CourseId: HUMAN_DRAFT_ID,
+      InternalEventName: HUMAN_EVENT,
+      CurrentModule: "DeckSelect",
+      ModulePayload: "{}",
+      CourseDeckSummary: { Attributes: [] },
+    }),
   ].join("");
 
   beforeAll(async () => {
@@ -308,5 +318,11 @@ describe("human draft in the 2026 log format", () => {
   it("identifies the draft by DraftId and event", () => {
     expect(globalStore.currentDraft.id).toBe(HUMAN_DRAFT_ID);
     expect(globalStore.currentDraft.eventId).toBe(HUMAN_EVENT);
+  });
+
+  it("emits DRAFT_END from DraftCompleteDraft", () => {
+    // One from the bot fixture's Completed status, one from here.
+    const ends = postedMessages.filter((m) => m.type === "DRAFT_END");
+    expect(ends.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/background/__tests__/draftParsing.spec.ts
+++ b/src/background/__tests__/draftParsing.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Bot-draft parsing against the 2026 log format, replayed through the watcher,
+ * the decoder and logEntrySwitch.
+ *
+ * The fixture is synthetic — hand-written lines mirroring the current client's
+ * shapes (separator-free labels, `<== Label(requestId)` responses with the JSON
+ * on the following line, `{"CurrentModule","Payload"}` wrappers, CardIds arrays)
+ * with made-up ids and card numbers. Do not replace it with a real Player.log:
+ * those carry account identifiers.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import backGlobalData from "../../utils/backGlobalData";
+import arenaLogWatcher from "../arena-log-watcher";
+import logEntrySwitch from "../logEntrySwitch";
+import globalStore from "../store";
+
+jest.setTimeout(30000);
+
+/** Everything the handlers broadcast during the replay, in order. */
+const postedMessages: { type: string }[] = [];
+
+const EVENT = "QuickDraft_TST_20990101";
+const COURSE_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+
+const req = (label: string, request: Record<string, unknown>): string =>
+  `[UnityCrossThreadLogger]==> ${label} ${JSON.stringify({
+    id: "ffffffff-0000-0000-0000-00000000000f",
+    request: JSON.stringify(request),
+  })}\n`;
+
+const res = (label: string, body: Record<string, unknown>): string =>
+  `<== ${label}(ffffffff-0000-0000-0000-00000000000f)\n${JSON.stringify(
+    body
+  )}\n`;
+
+const botDraftRes = (label: string, payload: Record<string, unknown>): string =>
+  res(label, { CurrentModule: "BotDraft", Payload: JSON.stringify(payload) });
+
+const FIXTURE = [
+  req("EventJoin", { EventName: EVENT }),
+  res("EventJoin", {
+    Course: {
+      CourseId: COURSE_ID,
+      InternalEventName: EVENT,
+      CurrentModule: "BotDraft",
+      ModulePayload: "",
+      CourseDeckSummary: { Attributes: [] },
+      CardPool: [],
+      CardStyles: [],
+    },
+    InventoryInfo: {},
+  }),
+  `[UnityCrossThreadLogger]Client.SceneChange {"fromSceneName":"EventLanding","toSceneName":"Draft","initiator":"System","context":"BotDraft"}\n`,
+  req("BotDraftDraftStatus", { EventName: EVENT }),
+  botDraftRes("BotDraftDraftStatus", {
+    Result: "Success",
+    EventName: EVENT,
+    DraftStatus: "PickNext",
+    PackNumber: 0,
+    PickNumber: 0,
+    NumCardsToPick: 1,
+    DraftPack: ["900001", "900002", "900003"],
+    PackStyles: [],
+    PickedCards: [],
+  }),
+  req("BotDraftDraftPick", {
+    EventName: EVENT,
+    PickInfo: {
+      EventName: EVENT,
+      CardIds: ["900002"],
+      PackNumber: 0,
+      PickNumber: 0,
+    },
+  }),
+  botDraftRes("BotDraftDraftPick", {
+    Result: "Success",
+    EventName: EVENT,
+    DraftStatus: "PickNext",
+    PackNumber: 0,
+    PickNumber: 1,
+    NumCardsToPick: 1,
+    DraftPack: ["900004", "900005"],
+    PackStyles: [],
+    PickedCards: ["900002"],
+  }),
+  req("BotDraftDraftPick", {
+    EventName: EVENT,
+    PickInfo: {
+      EventName: EVENT,
+      CardIds: ["900004"],
+      PackNumber: 0,
+      PickNumber: 1,
+    },
+  }),
+  botDraftRes("BotDraftDraftPick", {
+    Result: "Success",
+    EventName: EVENT,
+    DraftStatus: "PickNext",
+    PackNumber: 0,
+    PickNumber: 2,
+    NumCardsToPick: 1,
+    DraftPack: ["900006"],
+    PackStyles: [],
+    PickedCards: ["900002", "900004"],
+  }),
+  // The draft's last pick: the response repeats the same coordinates with
+  // DraftStatus "Completed" and an EMPTY DraftPack — it must not erase the
+  // one-card pack recorded by the response above.
+  req("BotDraftDraftPick", {
+    EventName: EVENT,
+    PickInfo: {
+      EventName: EVENT,
+      CardIds: ["900006"],
+      PackNumber: 0,
+      PickNumber: 2,
+    },
+  }),
+  botDraftRes("BotDraftDraftPick", {
+    Result: "Success",
+    EventName: EVENT,
+    DraftStatus: "Completed",
+    PackNumber: 0,
+    PickNumber: 2,
+    NumCardsToPick: 1,
+    DraftPack: [],
+    PackStyles: [],
+    PickedCards: ["900002", "900004", "900006"],
+  }),
+  `[UnityCrossThreadLogger]Client.SceneChange {"fromSceneName":"Draft","toSceneName":"DeckBuilder","initiator":"System","context":"deck builder"}\n`,
+  req("EventSetDeckV3", {
+    EventName: EVENT,
+    Summary: { DeckId: "bbbbbbbb-0000-0000-0000-000000000002", DeckTileId: 0 },
+    Deck: {
+      MainDeck: [
+        { cardId: 900002, quantity: 1 },
+        { cardId: 900004, quantity: 1 },
+      ],
+      Sideboard: [{ cardId: 900001, quantity: 1 }],
+      CommandZone: [],
+      Companions: [],
+    },
+  }),
+  req("EventGetCoursesV2", {}),
+  res("EventGetCoursesV2", {
+    Courses: [
+      {
+        CourseId: COURSE_ID,
+        InternalEventName: EVENT,
+        CurrentModule: "CreateMatch",
+        ModulePayload: "",
+        CurrentLosses: 1,
+      },
+    ],
+  }),
+].join("");
+
+function replay(content: string): Promise<Error[]> {
+  // Capture the channel traffic: DRAFT_END only exists as a broadcast, and it
+  // regressed silently once already (the decoder dropped scene lines whose
+  // JSON contained a space, e.g. "context":"deck builder").
+  (backGlobalData as any).broadcastChannel = {
+    postMessage: (m: { type: string }) => postedMessages.push(m),
+  };
+
+  const logPath = path.join(os.tmpdir(), "mtgatool-draft-spec.log");
+  fs.writeFileSync(logPath, content);
+
+  const errors: Error[] = [];
+  return new Promise((resolve) => {
+    arenaLogWatcher.start({
+      path: logPath,
+      chunkSize: 268435440,
+      onLogEntry: (entry: any) => logEntrySwitch(entry),
+      onError: (err: Error) => errors.push(err),
+      onFinish: () => {
+        fs.unlinkSync(logPath);
+        resolve(errors);
+      },
+    });
+  });
+}
+
+describe("bot draft in the 2026 log format", () => {
+  let errors: Error[];
+
+  beforeAll(async () => {
+    errors = await replay(FIXTURE);
+  });
+
+  it("replays without decoder errors", () => {
+    expect(errors).toEqual([]);
+  });
+
+  it("identifies the draft from the EventJoin response", () => {
+    expect(globalStore.currentDraft.id).toBe(COURSE_ID);
+    expect(globalStore.currentDraft.eventId).toBe(EVENT);
+    expect(globalStore.currentDraft.date).not.toBe("");
+  });
+
+  it("tracks packs as they are offered", () => {
+    expect(globalStore.currentDraft.packs[0][0]).toEqual([
+      900001, 900002, 900003,
+    ]);
+    expect(globalStore.currentDraft.packs[0][1]).toEqual([900004, 900005]);
+    expect(globalStore.currentDraft.currentPack).toBe(0);
+    expect(globalStore.currentDraft.currentPick).toBe(2);
+  });
+
+  it("keeps the final one-card pack despite the empty Completed status", () => {
+    expect(globalStore.currentDraft.packs[0][2]).toEqual([900006]);
+  });
+
+  it("tracks picks from the CardIds array", () => {
+    expect(globalStore.currentDraft.picks[0][0]).toBe(900002);
+    expect(globalStore.currentDraft.picks[0][1]).toBe(900004);
+    expect(globalStore.currentDraft.picks[0][2]).toBe(900006);
+    expect(globalStore.currentDraft.pickedCards).toEqual([
+      900002, 900004, 900006,
+    ]);
+  });
+
+  it("stores the submitted decklist on the draft record", () => {
+    expect(globalStore.currentDraft.deckId).toBe(
+      "bbbbbbbb-0000-0000-0000-000000000002"
+    );
+    expect(globalStore.currentDraft.deckMain).toEqual([
+      { id: 900002, quantity: 1 },
+      { id: 900004, quantity: 1 },
+    ]);
+    expect(globalStore.currentDraft.deckSide).toEqual([
+      { id: 900001, quantity: 1 },
+    ]);
+  });
+
+  it("emits DRAFT_END from the Completed status", () => {
+    // The end signal comes from the final pick response's DraftStatus, not the
+    // Draft->DeckBuilder scene line — that line's spaced JSON context ("deck
+    // builder") never makes it through the decoder's bare-label pattern.
+    expect(postedMessages.some((m) => m.type === "DRAFT_END")).toBe(true);
+  });
+
+  it("keeps the course, with its record, in currentCourses", () => {
+    const course = globalStore.currentCourses[EVENT];
+    expect(course).toBeDefined();
+    expect(course.CourseId).toBe(COURSE_ID);
+    expect(course.CurrentLosses).toBe(1);
+  });
+});

--- a/src/background/catchUpDraftFromMemory.ts
+++ b/src/background/catchUpDraftFromMemory.ts
@@ -23,6 +23,10 @@ import {
 export default async function catchUpDraftFromMemory(): Promise<void> {
   const memory = await readDraftMemory();
   if (!memory || memory.draftState !== 2) return;
+  // Registry pods outlive their draft with draftState still 2 — seeding from
+  // one resurrects a finished draft. Only the draft screen itself proves the
+  // draft is live; with the screen closed, catch-up simply waits for it.
+  if (memory.source !== "screen") return;
 
   const draft = globalStore.currentDraft;
   const eventName = memory.eventName || draft.eventId;
@@ -41,7 +45,9 @@ export default async function catchUpDraftFromMemory(): Promise<void> {
   // comes from the course (EventJoin / courses refresh) instead.
   if (!globalStore.currentDraft.id) {
     const course = globalStore.currentCourses[eventName];
-    const id = memory.draftId || (course && course.CourseId) || undefined;
+    // Course id first — it is what the log-driven handlers key records by;
+    // the pod's DraftId is a different GUID and would fork the record.
+    const id = (course && course.CourseId) || memory.draftId || undefined;
     if (id) setDraftId(id);
   }
 

--- a/src/background/catchUpDraftFromMemory.ts
+++ b/src/background/catchUpDraftFromMemory.ts
@@ -1,0 +1,70 @@
+import postChannelMessage from "../broadcastChannel/postChannelMessage";
+import readDraftMemory from "../reader/readDraftMemory";
+import getLocalSetting from "../utils/getLocalSetting";
+import getSetInEventId from "../utils/getSetInEventId";
+import loadDraftRatings from "../utils/seventeenLands";
+import globalStore from "./store";
+import {
+  setDraftData,
+  setDraftId,
+  setDraftPack,
+} from "./store/currentDraftStore";
+
+/**
+ * Seed the current draft from game memory — the case the log cannot cover:
+ * the app opened mid-draft, so the join/status entries replayed by nothing.
+ *
+ * Memory carries the position, the pack on offer and (while the draft screen
+ * is open) the full pick history in order; past packs exist nowhere on the
+ * client, so replays of the pre-catch-up stretch render from the picks alone.
+ * Runs once after the log catch-up finishes; the live entries take over from
+ * there.
+ */
+export default async function catchUpDraftFromMemory(): Promise<void> {
+  const memory = await readDraftMemory();
+  if (!memory || memory.draftState !== 2) return;
+
+  const draft = globalStore.currentDraft;
+  const eventName = memory.eventName || draft.eventId;
+  if (!eventName) return;
+
+  if (!draft.eventId) {
+    setDraftData({
+      eventId: eventName,
+      draftSet: getSetInEventId(eventName) ?? "",
+      date: draft.date || new Date().toISOString(),
+      arenaId: draft.arenaId || getLocalSetting("playerId"),
+    });
+  }
+
+  // Human pods carry the DraftId; bot pods leave it empty and the record id
+  // comes from the course (EventJoin / courses refresh) instead.
+  if (!globalStore.currentDraft.id) {
+    const course = globalStore.currentCourses[eventName];
+    const id = memory.draftId || (course && course.CourseId) || undefined;
+    if (id) setDraftId(id);
+  }
+
+  // The server-truth pick list beats whatever partial state the log gave us.
+  if (
+    Array.isArray(memory.pickedCards) &&
+    memory.pickedCards.length > globalStore.currentDraft.pickedCards.length
+  ) {
+    setDraftData({ pickedCards: memory.pickedCards });
+  }
+
+  if (
+    memory.packCards &&
+    memory.packCards.length > 0 &&
+    memory.currentPack !== undefined &&
+    memory.currentPick !== undefined
+  ) {
+    setDraftPack(memory.packCards, memory.currentPack, memory.currentPick);
+  }
+
+  loadDraftRatings(eventName);
+  postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
+  console.log(
+    `[draft] caught up from memory: ${eventName} pack ${memory.currentPack} pick ${memory.currentPick}`
+  );
+}

--- a/src/background/logEntrySwitch.ts
+++ b/src/background/logEntrySwitch.ts
@@ -90,7 +90,6 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "Event.GetPlayerCoursesV2":
-    case "EventGetCoursesV2":
       if (entry.arrow == "<==") {
         Labels.InEventGetPlayerCoursesV2(entry);
       }
@@ -175,6 +174,7 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "BotDraft_DraftStatus":
+    case "BotDraftDraftStatus":
       if (entry.arrow == "==>") {
         Labels.outBotDraftDraftStatus(entry);
       }
@@ -184,10 +184,18 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "BotDraft_DraftPick":
+    case "BotDraftDraftPick":
       if (entry.arrow == "<==") {
         Labels.InDraftMakePick(entry);
       } else {
         Labels.OutDraftMakePick(entry);
+      }
+      break;
+
+    case "Event_Join":
+    case "EventJoin":
+      if (entry.arrow == "<==") {
+        Labels.InEventJoin(entry);
       }
       break;
 
@@ -234,6 +242,7 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "Event_GetCourses":
+    case "EventGetCoursesV2":
       if (entry.arrow == "<==") {
         Labels.InEventGetCourses(entry);
       }

--- a/src/background/logEntrySwitch.ts
+++ b/src/background/logEntrySwitch.ts
@@ -68,6 +68,7 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "Event_PlayerDraftMakePick":
+    case "EventPlayerDraftMakePick":
       if (entry.arrow == "==>") {
         Labels.OutPlayerDraftMakePick(entry);
       } else if (entry.arrow == "<==") {
@@ -206,6 +207,7 @@ export default function logEntrySwitch(entry: LogEntry): void {
       break;
 
     case "Draft_CompleteDraft":
+    case "DraftCompleteDraft":
       if (entry.arrow == "<==") {
         Labels.InDraftCompleteDraft(entry);
       }

--- a/src/background/onLabel/InBotDraftDraftStatus.ts
+++ b/src/background/onLabel/InBotDraftDraftStatus.ts
@@ -1,6 +1,8 @@
 /* eslint-disable radix */
 import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import LogEntry from "../../types/logDecoder";
+import getSetInEventId from "../../utils/getSetInEventId";
+import loadDraftRatings from "../../utils/seventeenLands";
 import globalStore from "../store";
 import { setDraftData, setDraftPack } from "../store/currentDraftStore";
 
@@ -25,12 +27,39 @@ export default function InBotDraftDraftStatus(entry: Entry): void {
   const pick = json.PickNumber;
   const currentPack = (json.DraftPack || []).slice(0).map((n) => parseInt(n));
 
-  setDraftPack(currentPack, pack, pick);
+  // A "Completed" status repeats the last pick's coordinates with an empty
+  // DraftPack; writing it would erase the recorded one-card pack.
+  if (currentPack.length > 0) {
+    setDraftPack(currentPack, pack, pick);
+  }
+
+  // The server's picked list is authoritative — it also repairs state when the
+  // outgoing pick lines were missed (e.g. a catch-up read joining mid-draft).
+  if (json.PickedCards && json.PickedCards.length > 0) {
+    setDraftData({ pickedCards: json.PickedCards.map((n) => parseInt(n)) });
+  }
 
   const course = globalStore.currentCourses[json.EventName];
   if (course && course.CourseId && course.CourseId !== "") {
     setDraftData({ id: course.CourseId });
   }
 
+  // The set is derived from database.sets, which loads async from the cards
+  // worker — a draft joined before it lands gets an empty draftSet. Each
+  // status response is a chance to backfill it.
+  if (globalStore.currentDraft.draftSet === "" && json.EventName) {
+    setDraftData({ draftSet: getSetInEventId(json.EventName) ?? "" });
+  }
+
+  // Cached after the first call; re-broadcasts so a late-opening overlay
+  // still receives the ratings.
+  loadDraftRatings(json.EventName);
+
   postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
+
+  // A status poll after the last pick reports Completed too — same end signal
+  // as the final pick response (see InDraftMakePick).
+  if (json.DraftStatus === "Completed") {
+    postChannelMessage({ type: "DRAFT_END" });
+  }
 }

--- a/src/background/onLabel/InDraftCompleteDraft.ts
+++ b/src/background/onLabel/InDraftCompleteDraft.ts
@@ -1,15 +1,43 @@
+import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import LogEntry from "../../types/logDecoder";
 import getSetInEventId from "../../utils/getSetInEventId";
-import { setDraftData } from "../store/currentDraftStore";
+import globalStore from "../store";
+import { setDraftData, setDraftId } from "../store/currentDraftStore";
 
 interface Entry extends LogEntry {
-  json: { EventName: string; IsBotDraft: boolean };
+  json: {
+    // Old shape.
+    EventName?: string;
+    IsBotDraft?: boolean;
+    // 2026 shape: the response is the updated course.
+    CourseId?: string;
+    InternalEventName?: string;
+    CurrentModule?: string;
+  };
 }
+
+/**
+ * The draft is over. For human drafts this is the ONLY end signal — bot
+ * drafts get a "Completed" status response, humans just get this and move to
+ * deck selection.
+ */
 export default function InDraftCompleteDraft(entry: Entry): void {
   const { json } = entry;
 
   if (!json) return;
 
-  const set = getSetInEventId(json.EventName);
-  setDraftData({ draftSet: set, eventId: json.EventName });
+  const eventName = json.InternalEventName || json.EventName;
+  if (eventName) {
+    setDraftData({
+      draftSet:
+        globalStore.currentDraft.draftSet || (getSetInEventId(eventName) ?? ""),
+      eventId: eventName,
+    });
+  }
+  if (!globalStore.currentDraft.id && json.CourseId) {
+    setDraftId(json.CourseId);
+  }
+
+  postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
+  postChannelMessage({ type: "DRAFT_END" });
 }

--- a/src/background/onLabel/InDraftMakePick.ts
+++ b/src/background/onLabel/InDraftMakePick.ts
@@ -1,8 +1,11 @@
 /* eslint-disable radix */
 import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import LogEntry from "../../types/logDecoder";
+import getLocalSetting from "../../utils/getLocalSetting";
+import getSetInEventId from "../../utils/getSetInEventId";
+import loadDraftRatings from "../../utils/seventeenLands";
 import globalStore from "../store";
-import { setDraftPack } from "../store/currentDraftStore";
+import { setDraftData, setDraftPack } from "../store/currentDraftStore";
 
 interface Entry extends LogEntry {
   json: {
@@ -20,9 +23,51 @@ export default function onLabelInDraftMakePick(entry: Entry): void {
   const { json } = entry;
   if (!json) return;
 
+  // A restart mid-draft loses the in-memory draft (the join/status events do
+  // not re-fire); rebuild identity from what every pick response carries, and
+  // re-adopt the record id from the courses cache when it lands.
+  if (globalStore.currentDraft.eventId !== json.EventName) {
+    setDraftData({
+      eventId: json.EventName,
+      draftSet: getSetInEventId(json.EventName) ?? "",
+      date: globalStore.currentDraft.date || new Date().toISOString(),
+      arenaId: globalStore.currentDraft.arenaId || getLocalSetting("playerId"),
+    });
+  }
+  if (!globalStore.currentDraft.id) {
+    const course = globalStore.currentCourses[json.EventName];
+    if (course && course.CourseId) {
+      setDraftData({ id: course.CourseId });
+    }
+  }
+
   const cards = (json.DraftPack || []).map((n) => parseInt(n));
   const pack = json.PackNumber;
   const pick = json.PickNumber;
-  setDraftPack(cards, pack, pick);
+  // The draft's final response ("Completed") repeats the last pick's
+  // coordinates with an EMPTY DraftPack — writing that would erase the
+  // one-card pack the previous response recorded there.
+  if (cards.length > 0) {
+    setDraftPack(cards, pack, pick);
+  }
+
+  // The server's picked list is authoritative — it also repairs state when the
+  // outgoing pick lines were missed (e.g. a catch-up read joining mid-draft).
+  if (json.PickedCards && json.PickedCards.length > 0) {
+    setDraftData({ pickedCards: json.PickedCards.map((n) => parseInt(n)) });
+  }
+
+  // Cached after the first fetch; each pick re-broadcasts so an overlay that
+  // opened after the draft started still receives the ratings.
+  loadDraftRatings(json.EventName);
+
   postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
+
+  // The response to the final pick says so itself. The Draft->DeckBuilder
+  // scene change is NOT a reliable end signal: its JSON carries a spaced
+  // context ("deck builder"), which the log decoder's bare-label pattern
+  // cannot represent, so that entry never reaches the scene handler.
+  if (json.DraftStatus === "Completed") {
+    postChannelMessage({ type: "DRAFT_END" });
+  }
 }

--- a/src/background/onLabel/InDraftNotify.ts
+++ b/src/background/onLabel/InDraftNotify.ts
@@ -1,8 +1,11 @@
 /* eslint-disable radix */
 
+import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import { DraftNotify } from "../../types";
 import LogEntry from "../../types/logDecoder";
-import { setDraftPack } from "../store/currentDraftStore";
+import loadDraftRatings from "../../utils/seventeenLands";
+import globalStore from "../store";
+import { setDraftId, setDraftPack } from "../store/currentDraftStore";
 
 interface Entry extends LogEntry {
   json: DraftNotify;
@@ -16,4 +19,17 @@ export default function onLabelInDraftNotify(entry: Entry): void {
   const currentPack = json.PackCards.split(",").map((c) => parseInt(c));
   // packs and picks start at 1;
   setDraftPack(currentPack, json.SelfPack - 1, json.SelfPick - 1);
+
+  // Human drafts identify themselves by DraftId on every notification —
+  // survives a mid-draft restart where the EventJoin was never replayed.
+  if (!globalStore.currentDraft.id && json.draftId) {
+    setDraftId(json.draftId);
+  }
+
+  if (globalStore.currentDraft.eventId) {
+    loadDraftRatings(globalStore.currentDraft.eventId);
+  }
+
+  // Each notification is a new pack on offer — the overlay follows these.
+  postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
 }

--- a/src/background/onLabel/InEventGetCourses.ts
+++ b/src/background/onLabel/InEventGetCourses.ts
@@ -5,29 +5,31 @@ import globalStore from "../store";
 export interface Course {
   CourseId: string;
   InternalEventName: string;
-  CurrentModule: number;
+  CurrentModule: number | string;
   ModulePayload: string;
-  CourseDeckSummary: {
-    DeckId: string;
+  // A course fresh from EventJoin has no deck yet (drafts get one only after
+  // deck submission), and its summary carries no DeckId either.
+  CourseDeckSummary?: {
+    DeckId?: string;
     Name?: string;
     Description?: string;
     Attributes: {
       name: string;
       value: string;
     }[];
-    DeckTileId: number;
-    FormatLegalities: Record<string, string>;
-    DeckValidationSummaries: [];
-    UnownedCards: Record<string, string>;
+    DeckTileId?: number;
+    FormatLegalities?: Record<string, string>;
+    DeckValidationSummaries?: [];
+    UnownedCards?: Record<string, string>;
   };
-  CourseDeck: {
+  CourseDeck?: {
     MainDeck: v4cardsList;
-    ReducedSideboard: v4cardsList;
+    ReducedSideboard?: v4cardsList;
     Sideboard: v4cardsList;
-    CommandZone: v4cardsList;
-    Companions: v4cardsList;
-    CardSkins: v4cardsList;
-  };
+    CommandZone?: v4cardsList;
+    Companions?: v4cardsList;
+    CardSkins?: v4cardsList;
+  } | null;
   CardPool?: number[];
   JumpStart?: {
     CurrentChoices: [];

--- a/src/background/onLabel/InEventJoin.ts
+++ b/src/background/onLabel/InEventJoin.ts
@@ -1,15 +1,19 @@
 import { InternalDeck, ModuleInstanceData } from "../../types";
 import LogEntry from "../../types/logDecoder";
+import getLocalSetting from "../../utils/getLocalSetting";
 import getSetInEventId from "../../utils/getSetInEventId";
 import Deck from "../../utils/mtga/deck";
+import loadDraftRatings from "../../utils/seventeenLands";
 import selectDeck from "../selectDeck";
+import globalStore from "../store";
 import {
   resetCurrentDraft,
   setDraftData,
   setDraftId,
 } from "../store/currentDraftStore";
+import { Course } from "./InEventGetCourses";
 
-interface EntryJson {
+interface LegacyEntryJson {
   Id: string;
   InternalEventName: string;
   PlayerId: string | null;
@@ -22,21 +26,50 @@ interface EntryJson {
 }
 
 interface Entry extends LogEntry {
-  json: EntryJson;
+  json: Partial<LegacyEntryJson> & {
+    Course?: Course;
+  };
+}
+
+function beginDraft(eventName: string, courseId: string | undefined): void {
+  resetCurrentDraft();
+  setDraftData({
+    draftSet: getSetInEventId(eventName) ?? "",
+    eventId: eventName,
+    date: new Date().toISOString(),
+    arenaId: getLocalSetting("playerId"),
+  });
+  if (courseId) {
+    setDraftId(courseId);
+  }
+  loadDraftRatings(eventName);
 }
 
 export default function InEventJoin(entry: Entry): void {
   const { json } = entry;
 
+  // Current logs nest the course under Course (beside InventoryInfo for the
+  // entry fee); old logs put its fields at the top level.
+  const course = json.Course;
+  if (course) {
+    globalStore.currentCourses[course.InternalEventName] = course;
+    // A freshly joined course with no deck yet means a draft is starting. Deck
+    // selection for constructed events flows through EventSetDeckV3 instead.
+    const hasDeck =
+      course.CourseDeck &&
+      course.CourseDeck.MainDeck &&
+      course.CourseDeck.MainDeck.length > 0;
+    if (!hasDeck) {
+      beginDraft(course.InternalEventName, course.CourseId);
+    }
+    return;
+  }
+
   if (json.CourseDeck) {
     const deck = new Deck(json.CourseDeck);
-    // addCustomDeck(json.CourseDeck);
     selectDeck(deck);
-  } else {
+  } else if (json.InternalEventName) {
     // Most likely a draft
-    resetCurrentDraft();
-    const set = getSetInEventId(json.InternalEventName);
-    setDraftData({ draftSet: set, eventId: json.InternalEventName });
-    setDraftId(`${json.Id}-draft`);
+    beginDraft(json.InternalEventName, json.Id);
   }
 }

--- a/src/background/onLabel/MatchGameRoomStateChangedEvent.ts
+++ b/src/background/onLabel/MatchGameRoomStateChangedEvent.ts
@@ -103,15 +103,16 @@ export default async function onLabelMatchGameRoomStateChangedEvent(
     // let oppId = "";
 
     const course = globalStore.currentCourses[eventId];
-    if (course) {
+    // A course stored at EventJoin time has no deck until one is submitted.
+    if (course && course.CourseDeck) {
       // Should make a standard function to conver these new format decks
       const main = convertV4ListToV2(course.CourseDeck.MainDeck);
       const side = convertV4ListToV2(course.CourseDeck.Sideboard);
       const deck: InternalDeck = {
-        id: course.CourseDeckSummary.DeckId,
-        name: course.CourseDeckSummary.Name || "",
+        id: course.CourseDeckSummary?.DeckId ?? "",
+        name: course.CourseDeckSummary?.Name || "",
         lastUpdated: "",
-        deckTileId: course.CourseDeckSummary.DeckTileId,
+        deckTileId: course.CourseDeckSummary?.DeckTileId ?? 0,
         format: "",
         mainDeck: main,
         sideboard: side,

--- a/src/background/onLabel/OutDraftMakePick.ts
+++ b/src/background/onLabel/OutDraftMakePick.ts
@@ -9,7 +9,10 @@ interface Entry extends LogEntry {
     EventName: string;
     PickInfo: {
       EventName: string;
-      CardId: string;
+      // Old logs sent a single CardId; current logs send CardIds (an array,
+      // even for single-card picks).
+      CardId?: string;
+      CardIds?: string[];
       PackNumber: number;
       PickNumber: number;
     };
@@ -18,12 +21,17 @@ interface Entry extends LogEntry {
 
 export default function onLabelOutDraftMakePick(entry: Entry): void {
   const { json } = entry;
-  if (!json || !json) return;
+  if (!json || !json.PickInfo) return;
 
-  const grpId = parseInt(json.PickInfo.CardId);
+  const cardIds = json.PickInfo.CardIds ?? [json.PickInfo.CardId ?? ""];
   const pack = json.PickInfo.PackNumber;
   const pick = json.PickInfo.PickNumber;
 
-  addDraftPick(grpId, pack, pick);
+  cardIds.forEach((cardId) => {
+    const grpId = parseInt(cardId);
+    if (!Number.isNaN(grpId)) {
+      addDraftPick(grpId, pack, pick);
+    }
+  });
   postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
 }

--- a/src/background/onLabel/OutPlayerDraftMakePick.ts
+++ b/src/background/onLabel/OutPlayerDraftMakePick.ts
@@ -23,7 +23,12 @@ export default function onLabelOutPlayerDraftMakePick(entry: Entry): void {
   const { DraftId, Pack, Pick } = json;
   const grpIds = json.GrpIds ?? (json.GrpId ? [json.GrpId] : []);
 
-  setDraftId(DraftId);
+  // Only when nothing identified the draft yet: EventJoin keys the record by
+  // CourseId, and overwriting it with the (different) DraftId here forked the
+  // same draft into two records.
+  if (!globalStore.currentDraft.id) {
+    setDraftId(DraftId);
+  }
   grpIds.forEach((grpId) => {
     addDraftPick(
       grpId,

--- a/src/background/onLabel/OutPlayerDraftMakePick.ts
+++ b/src/background/onLabel/OutPlayerDraftMakePick.ts
@@ -1,21 +1,40 @@
 /* eslint-disable radix */
 import LogEntry from "../../types/logDecoder";
+import loadDraftRatings from "../../utils/seventeenLands";
+import globalStore from "../store";
 import { addDraftPick, setDraftId } from "../store/currentDraftStore";
 
 interface Entry extends LogEntry {
-  json: { DraftId: string; GrpId: number; Pack: number; Pick: number };
+  json: {
+    DraftId: string;
+    // Old logs sent a single GrpId; current logs send GrpIds (an array,
+    // even for single-card picks).
+    GrpId?: number;
+    GrpIds?: number[];
+    Pack: number;
+    Pick: number;
+  };
 }
 
 export default function onLabelOutPlayerDraftMakePick(entry: Entry): void {
   const { json } = entry;
 
   if (!json) return;
-  const { DraftId, Pack, Pick, GrpId } = json;
+  const { DraftId, Pack, Pick } = json;
+  const grpIds = json.GrpIds ?? (json.GrpId ? [json.GrpId] : []);
 
   setDraftId(DraftId);
-  addDraftPick(
-    GrpId,
-    Pack - 1, // packs and picks start at 1
-    Pick - 1
-  );
+  grpIds.forEach((grpId) => {
+    addDraftPick(
+      grpId,
+      Pack - 1, // packs and picks start at 1
+      Pick - 1
+    );
+  });
+
+  // Cached after the first fetch; re-broadcast so late-opening overlays get
+  // the ratings (human drafts have no per-pick status response to hook).
+  if (globalStore.currentDraft.eventId) {
+    loadDraftRatings(globalStore.currentDraft.eventId);
+  }
 }

--- a/src/background/onLabel/OutSetDeckV2.ts
+++ b/src/background/onLabel/OutSetDeckV2.ts
@@ -1,9 +1,11 @@
-// import postChannelMessage from "../../broadcastChannel/postChannelMessage";
-
+import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import { ArenaV4DeckPayload } from "../../types";
 import LogEntry from "../../types/logDecoder";
 import convertDeckFromV4 from "../../utils/convertDeckFromV4";
+import convertV4ListToV2 from "../../utils/convertV4ListToV2";
 import selectDeck from "../selectDeck";
+import globalStore from "../store";
+import { setDraftData } from "../store/currentDraftStore";
 
 interface Entry extends LogEntry {
   json: ArenaV4DeckPayload & {
@@ -15,10 +17,32 @@ export default function OutSetDeckV2(entry: Entry): any {
   const { json } = entry;
 
   selectDeck(convertDeckFromV4(json));
-  // postChannelMessage({
-  //   type: "UPSERT_DB_DECK",
-  //   value: deck,
-  // });
+
+  // Submitting a deck for the event we just drafted is the draft's final
+  // artifact — store it on the draft record so the replay can show it.
+  const draft = globalStore.currentDraft;
+  // After a mid-draft restart the id may only be recoverable here, from the
+  // courses refresh that precedes the deck submit.
+  if (!draft.id && draft.eventId === json.EventName) {
+    const course = globalStore.currentCourses[json.EventName];
+    if (course && course.CourseId) {
+      setDraftData({ id: course.CourseId });
+    }
+  }
+  // Re-read: setDraftData above replaces the store object, so the earlier
+  // reference would still show the missing id.
+  const current = globalStore.currentDraft;
+  if (current.id && current.eventId === json.EventName) {
+    setDraftData({
+      deckId: json.Summary.DeckId,
+      deckMain: convertV4ListToV2(json.Deck.MainDeck || []),
+      deckSide: convertV4ListToV2(json.Deck.Sideboard || []),
+    });
+    postChannelMessage({
+      type: "DRAFT_SAVE",
+      value: globalStore.currentDraft,
+    });
+  }
 
   return json;
 }

--- a/src/background/onLabel/outBotDraftDraftStatus.ts
+++ b/src/background/onLabel/outBotDraftDraftStatus.ts
@@ -2,7 +2,9 @@
 
 import postChannelMessage from "../../broadcastChannel/postChannelMessage";
 import LogEntry from "../../types/logDecoder";
+import getLocalSetting from "../../utils/getLocalSetting";
 import getSetInEventId from "../../utils/getSetInEventId";
+import loadDraftRatings from "../../utils/seventeenLands";
 import globalStore from "../store";
 import { resetCurrentDraft, setDraftData } from "../store/currentDraftStore";
 
@@ -15,14 +17,24 @@ export default function outBotDraftDraftStatus(entry: Entry): void {
 
   if (!json) return;
 
-  resetCurrentDraft();
-  const set = getSetInEventId(json.EventName);
-  setDraftData({ draftSet: set, eventId: json.EventName });
+  // A status request for an event we are not already tracking marks the start
+  // of a draft; a re-request mid-draft (reconnect, scene reload) must not wipe
+  // the picks accumulated so far.
+  if (globalStore.currentDraft.eventId !== json.EventName) {
+    resetCurrentDraft();
+    setDraftData({
+      draftSet: getSetInEventId(json.EventName) ?? "",
+      eventId: json.EventName,
+      date: new Date().toISOString(),
+      arenaId: getLocalSetting("playerId"),
+    });
+  }
 
   const course = globalStore.currentCourses[json.EventName];
   if (course && course.CourseId && course.CourseId !== "") {
     setDraftData({ id: course.CourseId });
   }
 
+  loadDraftRatings(json.EventName);
   postChannelMessage({ type: "DRAFT_STATUS", value: globalStore.currentDraft });
 }

--- a/src/background/store/currentDraftStore.ts
+++ b/src/background/store/currentDraftStore.ts
@@ -1,29 +1,31 @@
 import { InternalDraftv2 } from "../../types";
 import globalStore from ".";
 
-export const draftStateObject = {
-  archived: false,
-  type: "draft",
-  owner: "",
-  arenaId: "",
-  date: "",
-  eventId: "",
-  id: undefined,
-  draftSet: "",
-  currentPack: 0,
-  currentPick: 0,
-  pickedCards: [] as number[],
-  packs: [
-    Array(16).fill([]) as number[][],
-    Array(16).fill([]) as number[][],
-    Array(16).fill([]) as number[][],
-  ],
-  picks: [
-    Array(16).fill(0) as number[],
-    Array(16).fill(0) as number[],
-    Array(16).fill(0) as number[],
-  ],
-} as InternalDraftv2;
+export function createDraftState(): InternalDraftv2 {
+  return {
+    archived: false,
+    type: "draft",
+    owner: "",
+    arenaId: "",
+    date: "",
+    eventId: "",
+    id: undefined,
+    draftSet: "",
+    currentPack: 0,
+    currentPick: 0,
+    pickedCards: [],
+    packs: [
+      Array(16).fill([]) as number[][],
+      Array(16).fill([]) as number[][],
+      Array(16).fill([]) as number[][],
+    ],
+    picks: [
+      Array(16).fill(0) as number[],
+      Array(16).fill(0) as number[],
+      Array(16).fill(0) as number[],
+    ],
+  };
+}
 
 export function setDraftId(arg: string): void {
   globalStore.currentDraft.id = arg;
@@ -34,18 +36,7 @@ export function setDraftData(arg: Partial<InternalDraftv2>): void {
 }
 
 export function resetCurrentDraft(): void {
-  globalStore.currentDraft = { ...draftStateObject };
-  globalStore.currentDraft.pickedCards = [];
-  globalStore.currentDraft.packs = [
-    Array(16).fill([]) as number[][],
-    Array(16).fill([]) as number[][],
-    Array(16).fill([]) as number[][],
-  ];
-  globalStore.currentDraft.picks = [
-    Array(16).fill([]) as number[],
-    Array(16).fill([]) as number[],
-    Array(16).fill([]) as number[],
-  ];
+  globalStore.currentDraft = createDraftState();
 }
 
 function setDraftPackPick(pack: number, pick: number): void {

--- a/src/background/store/index.ts
+++ b/src/background/store/index.ts
@@ -1,7 +1,7 @@
 import { ActionLogV2 } from "../../components/action-log-v2/types";
 import { CombinedRankInfo } from "../onLabel/InEventGetCombinedRankInfo";
 import { Course } from "../onLabel/InEventGetCourses";
-import { draftStateObject } from "./currentDraftStore";
+import { createDraftState } from "./currentDraftStore";
 import { createMatchState } from "./currentMatchStore";
 
 // Use this store only when redux struggles with the data (too complex, too deep)
@@ -11,7 +11,7 @@ const globalStore = {
   // through this reference, so sharing it would mean the first match edits what
   // every later match resets to.
   currentMatch: createMatchState(),
-  currentDraft: draftStateObject,
+  currentDraft: createDraftState(),
   currentActionLog: {
     lines: [],
     players: [],

--- a/src/background/worker.ts
+++ b/src/background/worker.ts
@@ -3,6 +3,7 @@ import readCards from "../reader/readCards";
 import readDecks from "../reader/readDecks";
 import getLocalSetting from "../utils/getLocalSetting";
 import ArenaLogWatcher from "./arena-log-watcher";
+import catchUpDraftFromMemory from "./catchUpDraftFromMemory";
 import findInProgressMatch from "./findInProgressMatch";
 import logEntrySwitch from "./logEntrySwitch";
 import { isLiveLog, setLiveLog } from "./logReadState";
@@ -85,6 +86,9 @@ export default function start(): undefined | (() => void) {
           try {
             readDecks();
             readCards();
+            // A draft in progress that predates this session exists nowhere
+            // in the tailed log — memory is the only catch-up source.
+            catchUpDraftFromMemory().catch(() => undefined);
           } catch (e) {
             console.error(e);
           }

--- a/src/broadcastChannel/backgroundChannelListeners.ts
+++ b/src/broadcastChannel/backgroundChannelListeners.ts
@@ -1,10 +1,13 @@
+import globalStore from "../background/store";
 import start from "../background/worker";
 import bcConnect from "../utils/bcConnect";
 import defaultLogUri from "../utils/defaultLogUri";
 import electron from "../utils/electron/electronWrapper";
 import getLocalSetting from "../utils/getLocalSetting";
 import setLocalSetting from "../utils/setLocalSetting";
+import loadDraftRatings from "../utils/seventeenLands";
 import { ChannelMessage } from "./channelMessages";
+import postChannelMessage from "./postChannelMessage";
 
 export default function backgroundChannelListeners() {
   const channel = bcConnect() as any;
@@ -21,6 +24,17 @@ export default function backgroundChannelListeners() {
       console.log("STOP LOG READING");
       stopFn();
       stopFn = undefined;
+    }
+
+    // A draft overlay finished booting and missed the DRAFT_STATUS that opened
+    // it (the broadcast fired while the window was still loading). Re-send the
+    // current state so it doesn't sit empty until the next pick.
+    if (msg.data.type == "DRAFT_STATUS_REQUEST") {
+      const draft = globalStore.currentDraft;
+      if (draft.eventId) {
+        postChannelMessage({ type: "DRAFT_STATUS", value: draft });
+        loadDraftRatings(draft.eventId);
+      }
     }
   };
 

--- a/src/broadcastChannel/channelMessages.ts
+++ b/src/broadcastChannel/channelMessages.ts
@@ -5,6 +5,7 @@ import { ActionLogV2 } from "../components/action-log-v2/types";
 import { OverlaySharePayload } from "../data/liveShareTypes";
 import {
   Cards,
+  DraftRatings,
   InternalDraftv2,
   InternalMatch,
   InventoryUpdate,
@@ -40,6 +41,9 @@ export type MessageType =
   | "HOVER_IN"
   | "HOVER_OUT"
   | "DRAFT_STATUS"
+  | "DRAFT_STATUS_REQUEST"
+  | "DRAFT_SAVE"
+  | "DRAFT_RATINGS"
   | "DRAFT_VOTES"
   | "DRAFT_END"
   | "UPDATE_ACTIVE_EVENTS"
@@ -200,6 +204,32 @@ export interface DraftStatusMessage extends ChannelMessageBase {
   value: InternalDraftv2;
 }
 
+/**
+ * An overlay window asking the background for the current draft state. The
+ * overlay opens BECAUSE of a DRAFT_STATUS broadcast, so by the time it has
+ * booted and wired its listener that broadcast is long gone — without this it
+ * would sit empty until the next pick.
+ */
+export interface DraftStatusRequestMessage extends ChannelMessageBase {
+  type: "DRAFT_STATUS_REQUEST";
+}
+
+/**
+ * Persist a draft record without implying a draft is running — DRAFT_STATUS
+ * flips draftInProgress (opening overlays), which a post-draft save like the
+ * decklist submission must not do.
+ */
+export interface DraftSaveMessage extends ChannelMessageBase {
+  type: "DRAFT_SAVE";
+  value: InternalDraftv2;
+}
+
+/** 17lands ratings for the set being drafted, for the overlay to rank with. */
+export interface DraftRatingsMessage extends ChannelMessageBase {
+  type: "DRAFT_RATINGS";
+  value: DraftRatings;
+}
+
 export interface DraftVotesMessage extends ChannelMessageBase {
   type: "DRAFT_VOTES";
   value: Record<string, DbDraftVote>;
@@ -299,6 +329,9 @@ export type ChannelMessage =
   | HoverOutMessage
   | OverlaySettingsMessage
   | DraftStatusMessage
+  | DraftStatusRequestMessage
+  | DraftSaveMessage
+  | DraftRatingsMessage
   | DraftVotesMessage
   | DraftEndMessage
   | UpdateActiveEventsMessage

--- a/src/broadcastChannel/mainChannelListeners.ts
+++ b/src/broadcastChannel/mainChannelListeners.ts
@@ -2,8 +2,11 @@ import _ from "lodash";
 
 import { overlayTitleToId } from "../common/maps";
 import { LOGIN_OK } from "../constants";
+import { pushDraft } from "../data/cloudSync";
+import { isDraftDeleted } from "../data/deletedDrafts";
 import setDbMatch from "../data/setDbMatch";
-import { putData } from "../data/store";
+import { getUserNamespacedKey, putData } from "../data/store";
+import syncDrafts from "../data/syncDrafts";
 import syncMatches from "../data/syncMatches";
 import upsertDbCards from "../data/upsertDbCards";
 import upsertDbInventory from "../data/upsertDbInventory";
@@ -18,6 +21,7 @@ import store from "../redux/stores/rendererStore";
 import { InternalDraftv2 } from "../types";
 import LogEntry from "../types/logDecoder";
 import bcConnect from "../utils/bcConnect";
+import getLocalSetting from "../utils/getLocalSetting";
 import globalData from "../utils/globalData";
 import switchPlayerUUID from "../utils/switchPlayerUUID";
 import { ChannelMessage } from "./channelMessages";
@@ -30,6 +34,32 @@ export default function mainChannelListeners() {
 
   let last = Date.now();
 
+  // Debounces the IndexedDB upsert across DRAFT_STATUS bursts (one message per
+  // pick); must outlive a single onmessage call to actually debounce.
+  let draftUpsertTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const upsertDraft = async (draft: InternalDraftv2) => {
+    if (!draft.id || draft.id === "") return;
+    // The user deleted this one on purpose; a full log re-import must not
+    // bring it back.
+    if (await isDraftDeleted(draft.id)) return;
+    reduxAction(store.dispatch, {
+      type: "SET_CURRENT_DRAFT",
+      arg: draft,
+    });
+    putData<InternalDraftv2>(`draft-${draft.id}`, draft, true);
+    // Keep the index current so a draft finished this session shows up in the
+    // list without a relog.
+    const fullKey = getUserNamespacedKey(`draft-${draft.id}`);
+    if (!globalData.draftsIndex.includes(fullKey)) {
+      globalData.draftsIndex = [...globalData.draftsIndex, fullKey];
+      reduxAction(store.dispatch, {
+        type: "SET_DRAFTS_INDEX",
+        arg: globalData.draftsIndex,
+      });
+    }
+  };
+
   // Reconcile matches to the cloud once we actually know the persona (arena_id).
   // Matches saved during the catch-up read before this point have no persona,
   // so syncMatches at login pushed nothing; re-run it when the persona lands.
@@ -38,6 +68,7 @@ export default function mainChannelListeners() {
     if (uuid && uuid !== syncedPersona) {
       syncedPersona = uuid;
       syncMatches().catch(() => undefined);
+      syncDrafts().catch(() => undefined);
     }
   };
 
@@ -160,30 +191,28 @@ export default function mainChannelListeners() {
         type: "SET_DRAFT_IN_PROGRESS",
         arg: true,
       });
+
+      const draft = msg.data.value;
+      if (draftUpsertTimeout !== null) {
+        clearTimeout(draftUpsertTimeout);
+      }
+      draftUpsertTimeout = setTimeout(() => {
+        draftUpsertTimeout = null;
+        upsertDraft(draft);
+      }, 250);
     }
 
-    let draftUpsertTImeout = null;
-    if (msg.data.type === "DRAFT_STATUS") {
-      if (draftUpsertTImeout !== null) {
-        clearTimeout(draftUpsertTImeout);
+    // Same upsert as DRAFT_STATUS but without marking a draft as in progress —
+    // used for post-draft additions like the submitted decklist. This is also
+    // the "draft is complete" moment, so it mirrors to the cloud.
+    if (msg.data.type === "DRAFT_SAVE") {
+      const draft = msg.data.value;
+      upsertDraft(draft);
+      if (draft.id) {
+        pushDraft(draft.arenaId || getLocalSetting("playerId"), draft).catch(
+          () => undefined
+        );
       }
-      draftUpsertTImeout = setTimeout(() => {
-        if (
-          msg.data.type === "DRAFT_STATUS" &&
-          msg.data.value.id &&
-          msg.data.value.id !== ""
-        ) {
-          reduxAction(store.dispatch, {
-            type: "SET_CURRENT_DRAFT",
-            arg: msg.data.value,
-          });
-          putData<InternalDraftv2>(
-            `draft-${msg.data.value.id}`,
-            msg.data.value,
-            true
-          );
-        }
-      }, 250);
     }
 
     if (msg.data.type === "DRAFT_END") {
@@ -191,6 +220,15 @@ export default function mainChannelListeners() {
         type: "SET_DRAFT_IN_PROGRESS",
         arg: false,
       });
+      // Leaving the draft scene is the other completion signal — the deck
+      // submit (DRAFT_SAVE) may come much later or never, so mirror what we
+      // have now.
+      const draft = store.getState().renderer.currentDraft;
+      if (draft && draft.id) {
+        pushDraft(draft.arenaId || getLocalSetting("playerId"), draft).catch(
+          () => undefined
+        );
+      }
     }
 
     if (msg.data.type == "OVERLAY_UPDATE_BOUNDS") {

--- a/src/common/defaultConfig.ts
+++ b/src/common/defaultConfig.ts
@@ -38,6 +38,8 @@ const overlayCfg = {
   typeCounts: false,
   autosize: false,
   collapsed: false,
+  // Draft overlay: color share of the cards picked so far, at the top.
+  draftStats: true,
   // Live-share: a persistent unguessable token per overlay. While shareEnabled
   // this overlay's live state is broadcast (Supabase Realtime) to the public
   // viewer at app.mtgatool.com/live/<shareId> — the URL the overlay QR encodes.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -61,6 +61,7 @@ function App(props: AppProps) {
     backgroundGrpid,
     customBackground,
     matchInProgress,
+    draftInProgress,
   } = useSelector((state: AppState) => state.renderer);
 
   const os = forceOs || (isElectron() ? process.platform : "");
@@ -78,11 +79,13 @@ function App(props: AppProps) {
       .catch(() => undefined);
   }, [dispatch]);
 
+  // Overlays open and close on these flags — a draft overlay that only
+  // re-evaluated on settings changes would never appear when a draft starts.
   useEffect(() => {
     if (overlayHandler) {
       overlayHandler.settingsUpdated();
     }
-  }, [matchInProgress]);
+  }, [matchInProgress, draftInProgress]);
 
   useEffect(() => {
     // The public live-share viewer (/live/<token>) must work with no account —

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -16,6 +16,7 @@ import {
   requestPasswordReset,
   resetPasswordWithCode,
 } from "../data/passwordReset";
+import syncDrafts from "../data/syncDrafts";
 import syncMatches from "../data/syncMatches";
 import UICheckAdmin from "../reader/uiCheckAdmin";
 import reduxAction from "../redux/reduxAction";
@@ -190,6 +191,7 @@ export default function Auth(props: AuthProps) {
         // waits on the log read — so a fresh login showed every match with the
         // "not uploaded" arrow until then, and a restart appeared to fix it.
         syncMatches().catch(() => undefined);
+        syncDrafts().catch(() => undefined);
 
         if (electron) {
           postChannelMessage({

--- a/src/components/CardTile.tsx
+++ b/src/components/CardTile.tsx
@@ -94,6 +94,8 @@ export interface QuantityNumber extends CardTileQuantityBase {
 export interface QuantityRank extends CardTileQuantityBase {
   type: "RANK";
   quantity: string;
+  /** Copies already in the collection (0-4); renders as pips beside the rank. */
+  owned?: number;
 }
 
 export interface QuantityText extends CardTileQuantityBase {
@@ -205,8 +207,29 @@ function CardQuantityDisplay(props: {
   if (quantity.type == "RANK") {
     // Text quantity, presumably rank
     const rankClass = getRankColorClass(quantity.quantity);
+    const { owned } = quantity;
     return (
-      <div className={`card-tile-odds-flat ${rankClass}`}>
+      <div
+        className={`card-tile-odds-flat ${rankClass}${
+          owned !== undefined ? " with-owned-pips" : ""
+        }`}
+        title={
+          owned !== undefined
+            ? `You own ${owned >= 4 ? "4+" : owned}`
+            : undefined
+        }
+      >
+        {owned !== undefined && (
+          <div className="draft-owned-pips">
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={`owned-pip-${i}`}
+                className={`pip${i < owned ? " owned" : ""}`}
+              />
+            ))}
+          </div>
+        )}
         {quantity.quantity}
       </div>
     );

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -23,6 +23,10 @@ interface WhatsNewItem {
  */
 const NEW_IN_THIS_VERSION: WhatsNewItem[] = [
   {
+    title: "Draft tracking is back (Quick Draft)",
+    body: "The draft overlay works again for bot drafts: it follows your packs as you pick, ranks the cards with live 17lands data, and the draft is saved with its event so results can be tracked. The Drafts tab now lists your past drafts, and opening one replays it pick by pick — including the card pool and the deck you submitted. Drafts sync to your account like matches do. Premier and Traditional draft support is coming next.",
+  },
+  {
     title: "Post-match overview",
     body: "Resurrected post match overview popup when a match ends: life totals through each game, cards cast, mana spent, and a turn-by-turn timeline of how it played out.",
   },

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -84,7 +84,7 @@ const NEW_IN_V7: WhatsNewItem[] = [
   },
   {
     title: "Timeline",
-    body: "Win rate and rank progression over time, with bands showing which deck you played across each stretch and a badge each time you rank up.",
+    body: "Win rate and rank progression over time — Constructed and Limited ranks charted separately — with bands showing which deck you played across each stretch and a badge each time you rank up.",
   },
   {
     title: "Saved decks & Explore",

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -23,8 +23,8 @@ interface WhatsNewItem {
  */
 const NEW_IN_THIS_VERSION: WhatsNewItem[] = [
   {
-    title: "Draft tracking is back (Quick Draft)",
-    body: "The draft overlay works again for bot drafts: it follows your packs as you pick, ranks the cards with live 17lands data, and the draft is saved with its event so results can be tracked. The Drafts tab now lists your past drafts, and opening one replays it pick by pick — including the card pool and the deck you submitted. Drafts sync to your account like matches do. Premier and Traditional draft support is coming next.",
+    title: "Draft tracking is back",
+    body: "The draft overlay works again — Quick, Premier and Traditional: it follows your packs as you pick, ranks the cards with live 17lands data, and the draft is saved with its event so results can be tracked. The Drafts tab lists your past drafts with date and event filters (all Quick Drafts, all drafts of a set...), shows your win rate for whatever is filtered, and opening a draft replays it pick by pick — including the card pool and the deck you submitted. Drafts sync to your account like matches do.",
   },
   {
     title: "Post-match overview",

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -84,7 +84,7 @@ const NEW_IN_V7: WhatsNewItem[] = [
   },
   {
     title: "Timeline",
-    body: "Win rate and rank progression over time — Constructed and Limited ranks charted separately — with bands showing which deck you played across each stretch and a badge each time you rank up.",
+    body: "Win rate and rank progression over time, switchable between Constructed and Limited (their ladders and ranks are separate), with bands showing which deck you played across each stretch and a badge each time you rank up.",
   },
   {
     title: "Saved decks & Explore",

--- a/src/components/views/drafts/CardLiveDraft.tsx
+++ b/src/components/views/drafts/CardLiveDraft.tsx
@@ -1,31 +1,36 @@
-import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import { CSSProperties, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 
 import LoadingCard from "../../../assets/images/loadingcard.png";
 import { CARD_SIZE_RATIO } from "../../../common/static";
+import useCard from "../../../hooks/useCard";
 import useHoverCard from "../../../hooks/useHoverCard";
 import { AppState } from "../../../redux/stores/rendererStore";
 import { getCardImage } from "../../../utils/getCardArtCrop";
 import getCssQuality from "../../../utils/getCssQuality";
-import database from "../../../utils/mtga/database";
 
 interface CardLiveDraftProps {
   grpId: number;
-  onClick: () => void;
+  selected?: boolean;
+  /** Fixed width in px; defaults to the user's card-size setting. */
+  size?: number;
+  onClick?: () => void;
 }
 
 export default function CardLiveDraft(props: CardLiveDraftProps) {
-  const { grpId, onClick } = props;
-  const containerEl = useRef<HTMLDivElement>(null);
+  const { grpId, selected, size, onClick } = props;
 
   const [hoverIn, hoverOut] = useHoverCard(grpId);
   const [cardUrl, setCardUrl] = useState<string>();
 
-  const cardSize =
+  const settingsSize =
     100 + useSelector((state: AppState) => state.settings.cardsSize) * 15;
+  const cardSize = size ?? settingsSize;
   const cardsQuality = useSelector(
     (state: AppState) => state.settings.cardsQuality
   );
+
+  const card = useCard(grpId);
 
   const style = useMemo((): CSSProperties => {
     return {
@@ -34,28 +39,27 @@ export default function CardLiveDraft(props: CardLiveDraftProps) {
   }, [cardUrl]);
 
   useEffect(() => {
+    if (!card) return undefined;
+    let cancelled = false;
     const img = new Image();
-    const card = database.card(grpId);
-    if (card) {
-      const imageUrl = getCardImage(card, cardsQuality);
-      img.src = imageUrl;
-      img.onload = (): void => {
-        setCardUrl(imageUrl);
-      };
-    }
-  }, [grpId]);
-
-  const card = database.card(grpId);
+    const imageUrl = getCardImage(card, cardsQuality);
+    img.src = imageUrl;
+    img.onload = (): void => {
+      if (!cancelled) setCardUrl(imageUrl);
+    };
+    return () => {
+      cancelled = true;
+    };
+  }, [card, cardsQuality]);
 
   return (
     <div
-      ref={containerEl}
       title={`${card?.Name || ""}`}
       onClick={onClick}
       style={{ display: "flex", flexDirection: "column", alignItems: "center" }}
     >
       <div
-        className="inventory-card"
+        className={`inventory-card${selected ? " draft-pick-selected" : ""}`}
         onMouseEnter={hoverIn}
         onMouseLeave={hoverOut}
         style={{
@@ -68,6 +72,7 @@ export default function CardLiveDraft(props: CardLiveDraftProps) {
           className={`inventory-card-img ${getCssQuality()}`}
           style={{ ...style }}
         />
+        {selected && <div className="draft-pick-selected-badge">PICK</div>}
       </div>
     </div>
   );

--- a/src/components/views/drafts/DraftView.tsx
+++ b/src/components/views/drafts/DraftView.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from "react";
+import { useHistory, useParams } from "react-router-dom";
+
+import { ReactComponent as BackIcon } from "../../../assets/images/svg/back.svg";
+import { getData } from "../../../data/store";
+import { useCards } from "../../../hooks/useCard";
+import { InternalDraftv2 } from "../../../types";
+import getEventPrettyName from "../../../utils/getEventPrettyName";
+import Deck from "../../../utils/mtga/deck";
+import timeAgo from "../../../utils/timeAgo";
+import CardTile from "../../CardTile";
+import DeckList from "../../DeckList";
+import SvgButton from "../../SvgButton";
+import Button from "../../ui/Button";
+import Section from "../../ui/Section";
+import CardLiveDraft from "./CardLiveDraft";
+
+interface DraftStep {
+  pack: number;
+  pick: number;
+}
+
+export default function DraftView() {
+  const params = useParams<{ id: string }>();
+  const history = useHistory();
+
+  const [draft, setDraft] = useState<InternalDraftv2 | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [showDeck, setShowDeck] = useState(false);
+
+  useEffect(() => {
+    getData<InternalDraftv2>(decodeURIComponent(params.id)).then((record) => {
+      if (record) setDraft(record);
+    });
+  }, [params.id]);
+
+  // Every pack/pick that actually happened, in draft order. A recorded pick
+  // with no stored pack still counts: records saved before the "Completed"
+  // clobber fix lost the final one-card pack, but the pick itself names it.
+  const steps = useMemo((): DraftStep[] => {
+    if (!draft) return [];
+    const list: DraftStep[] = [];
+    draft.packs.forEach((packRounds, pack) => {
+      packRounds.forEach((cards, pick) => {
+        const hasPack = cards && cards.length > 0;
+        const hasPick = draft.picks[pack] && draft.picks[pack][pick] > 0;
+        if (hasPack || hasPick) {
+          list.push({ pack, pick });
+        }
+      });
+    });
+    return list;
+  }, [draft]);
+
+  const step = steps[Math.min(stepIndex, Math.max(steps.length - 1, 0))];
+  const packCards = useMemo(() => {
+    if (!draft || !step) return [];
+    const stored = draft.packs[step.pack][step.pick];
+    if (stored && stored.length > 0) return stored;
+    // Lost pack, known pick — show the card that was taken from it.
+    const picked = draft.picks[step.pack][step.pick];
+    return picked > 0 ? [picked] : [];
+  }, [draft, step]);
+  const chosen = draft && step ? draft.picks[step.pack][step.pick] : 0;
+  // One card leaves the pool per step, so the pool before this step is the
+  // first stepIndex entries of the cumulative picked list.
+  const poolSoFar = useMemo(
+    () => (draft ? draft.pickedCards.slice(0, stepIndex) : []),
+    [draft, stepIndex]
+  );
+
+  // Prefetch this pack's images and resolve the pool's tiles.
+  useCards(packCards);
+  const poolCards = useCards(poolSoFar);
+
+  const deck = useMemo(() => {
+    if (!draft || !draft.deckMain) return null;
+    return new Deck({
+      id: draft.deckId ?? "",
+      name: getEventPrettyName(draft.eventId),
+      mainDeck: draft.deckMain,
+      sideboard: draft.deckSide ?? [],
+    });
+  }, [draft]);
+
+  if (!draft) {
+    return <></>;
+  }
+
+  const lastStep = Math.max(steps.length - 1, 1);
+  const progress = (Math.min(stepIndex, lastStep) / lastStep) * 100;
+
+  // Step indices where a new pack begins (pack 2 and 3), for the scrubber's
+  // dividers; segments feed the "Pack N" labels underneath.
+  const packStarts: number[] = [];
+  steps.forEach((s, i) => {
+    if (i > 0 && s.pack !== steps[i - 1].pack) packStarts.push(i);
+  });
+  const segmentBounds = [0, ...packStarts, steps.length];
+
+  return (
+    <div className="draft-view-grid">
+      <Section className="draft-view-header">
+        <SvgButton
+          svg={BackIcon}
+          style={{ height: "32px", width: "32px" }}
+          onClick={() => history.push("/drafts")}
+        />
+        <h2>
+          {getEventPrettyName(draft.eventId)}
+          {draft.draftSet ? ` — ${draft.draftSet}` : ""}
+        </h2>
+        <div className="draft-replay-date">
+          {draft.date ? timeAgo(new Date(draft.date).getTime()) : ""}
+        </div>
+        {deck && (
+          <div className="draft-replay-deck-toggle">
+            <Button
+              text={showDeck ? "Back to replay" : "Show final deck"}
+              onClick={() => setShowDeck(!showDeck)}
+            />
+          </div>
+        )}
+      </Section>
+
+      <Section className="draft-view-pack">
+        {showDeck && deck ? (
+          <div className="draft-replay-deck">
+            <DeckList deck={deck} showWildcards={false} />
+          </div>
+        ) : (
+          <>
+            {step && (
+              <div className="draft-replay-nav">
+                <Button
+                  text="◀"
+                  disabled={stepIndex === 0}
+                  onClick={() => setStepIndex(Math.max(0, stepIndex - 1))}
+                />
+                <h3>{`Pack ${step.pack + 1} · Pick ${step.pick + 1}`}</h3>
+                <Button
+                  text="▶"
+                  disabled={stepIndex >= steps.length - 1}
+                  onClick={() =>
+                    setStepIndex(Math.min(steps.length - 1, stepIndex + 1))
+                  }
+                />
+              </div>
+            )}
+            <div className="draft-replay-scrubber">
+              <div className="track">
+                <div className="bar" style={{ width: `${progress}%` }} />
+                {packStarts.map((i) => (
+                  <div
+                    key={`pack-tick-${i}`}
+                    className="tick"
+                    style={{ left: `${(i / lastStep) * 100}%` }}
+                  />
+                ))}
+                <div className="thumb" style={{ left: `${progress}%` }} />
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={lastStep}
+                value={Math.min(stepIndex, lastStep)}
+                onChange={(e) => setStepIndex(parseInt(e.target.value, 10))}
+              />
+              <div className="labels">
+                {segmentBounds.slice(0, -1).map((start, seg) => {
+                  const end = segmentBounds[seg + 1];
+                  const center = ((start + end - 1) / 2 / lastStep) * 100;
+                  return (
+                    <div
+                      key={`pack-label-${start}`}
+                      className="label"
+                      style={{ left: `${center}%` }}
+                    >
+                      {`Pack ${steps[start].pack + 1}`}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="pack-container">
+              {packCards.map((grpId, i) => (
+                <CardLiveDraft
+                  // A pack can hold duplicate grpIds, so position is the key.
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${grpId}-${i}-draft-replay`}
+                  grpId={grpId}
+                  selected={grpId === chosen}
+                  size={150}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </Section>
+
+      <Section className="draft-view-picked">
+        <h3>{`Picked (${poolSoFar.length})`}</h3>
+        <div className="picks-list">
+          {poolCards.map((card, i) =>
+            card ? (
+              <CardTile
+                // eslint-disable-next-line react/no-array-index-key
+                key={`draft-pool-${card.GrpId}-${i}`}
+                card={card}
+                indent="a"
+                isHighlighted={false}
+                isSideboard={false}
+                quantity={{ type: "NUMBER", quantity: 1 }}
+                showWildcards={false}
+              />
+            ) : null
+          )}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/views/drafts/DraftsHome.tsx
+++ b/src/components/views/drafts/DraftsHome.tsx
@@ -1,68 +1,138 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
+import deleteDraft from "../../../data/deleteDraft";
+import { getData } from "../../../data/store";
 import { AppState } from "../../../redux/stores/rendererStore";
-import Button from "../../ui/Button";
+import { InternalDraftv2 } from "../../../types";
+import isElectron from "../../../utils/electron/isElectron";
+import getEventPrettyName from "../../../utils/getEventPrettyName";
+import getPopupClass from "../../../utils/getPopupClass";
+import timeAgo from "../../../utils/timeAgo";
+import PopupComponent from "../../PopupComponent";
+import ConfirmDialog from "../../popups/ConfirmDialog";
+import Section from "../../ui/Section";
+import ListItemDraft from "./ListItemDraft";
+
+interface DraftRecord {
+  key: string;
+  draft: InternalDraftv2;
+}
+
+const voidFn = (): void => undefined;
 
 export default function DraftsHome() {
   const history = useHistory();
-  const draftInProgress = useSelector(
-    (state: AppState) => state.renderer.draftInProgress
-  );
-  const [liveDraftUrl, _setLiveDraftUrl] = useState<string | undefined>(
-    undefined
+
+  const draftsIndex = useSelector(
+    (state: AppState) => state.mainData.draftsIndex
   );
 
-  const currentDraft = useSelector(
-    (state: AppState) => state.renderer.currentDraft
+  const [records, setRecords] = useState<DraftRecord[]>([]);
+
+  const os = isElectron() ? process.platform : "";
+  const openDeleteDraft = useRef<() => void>(voidFn);
+  const closeDeleteDraft = useRef<() => void>(voidFn);
+  const [draftToDelete, setDraftToDelete] = useState<InternalDraftv2 | null>(
+    null
   );
 
-  const beginLiveDraft = useCallback(() => {
-    // Live draft sharing was a tool-db p2p feature; removed with tool-db.
-  }, [history, currentDraft]);
+  const askDeleteDraft = useCallback((draft: InternalDraftv2) => {
+    setDraftToDelete(draft);
+    openDeleteDraft.current();
+  }, []);
+
+  // deleteDraft dispatches the shrunken draftsIndex, which re-runs the loader
+  // effect below — nothing else to refresh.
+  const confirmDeleteDraft = useCallback(() => {
+    if (draftToDelete?.id) deleteDraft(draftToDelete.id);
+  }, [draftToDelete]);
+
+  useEffect(() => {
+    Promise.all(
+      draftsIndex.map((key) =>
+        getData<InternalDraftv2>(key).then((draft) =>
+          draft ? { key, draft } : null
+        )
+      )
+    ).then((results) => {
+      const loaded = results.filter((r): r is DraftRecord => r !== null);
+      // Newest first; records without a date sink to the bottom.
+      loaded.sort(
+        (a, b) =>
+          new Date(b.draft.date || 0).getTime() -
+          new Date(a.draft.date || 0).getTime()
+      );
+      setRecords(loaded);
+    });
+  }, [draftsIndex]);
 
   return (
-    <>
-      {draftInProgress ? (
-        <>
-          {liveDraftUrl === undefined ? (
-            <>
-              <Button onClick={beginLiveDraft} text="Start" />
-              <p style={{ marginBottom: "16px" }}>Start Live Draft session</p>
-            </>
-          ) : (
-            <div className="input-container" style={{ height: "40px" }}>
-              <label className="label">
-                Use this link to share your draft in real time:
-              </label>
-              <div
-                style={{
-                  display: "flex",
-                  maxWidth: "80%",
-                  width: "-webkit-fill-available",
-                  justifyContent: "flex-end",
-                }}
-              >
-                <div
-                  style={{ marginLeft: "16px" }}
-                  className="form-input-container"
-                >
-                  <input autoComplete="off" readOnly value={liveDraftUrl} />
-                </div>
-              </div>
-            </div>
-          )}
-        </>
-      ) : (
+    <Section
+      style={{
+        marginTop: "16px",
+        flexDirection: "column",
+        textAlign: "center",
+      }}
+    >
+      {records.length === 0 ? (
         <>
           <div className="wip-sign" />
-          <h1>Working on it</h1>
+          <h1>No drafts yet</h1>
           <p style={{ marginBottom: "16px" }}>
-            Our team of expert Goblins are working here.
+            Your drafts are recorded as you make picks — start one in Arena and
+            it will show up here.
           </p>
         </>
+      ) : (
+        <div className="drafts-list">
+          {records.map((record) => (
+            <ListItemDraft
+              key={record.key}
+              draft={record.draft}
+              deleteCallback={askDeleteDraft}
+              onClick={() =>
+                history.push(`/drafts/${encodeURIComponent(record.key)}`)
+              }
+            />
+          ))}
+        </div>
       )}
-    </>
+
+      <PopupComponent
+        open={false}
+        className={getPopupClass(os)}
+        width="480px"
+        height="auto"
+        openFnRef={openDeleteDraft}
+        closeFnRef={closeDeleteDraft}
+        persistent={false}
+        onClose={(): void => setDraftToDelete(null)}
+      >
+        <ConfirmDialog
+          title="Delete draft?"
+          danger
+          confirmText="Delete"
+          onConfirm={confirmDeleteDraft}
+          onClose={(): void => closeDeleteDraft.current()}
+          text={
+            draftToDelete ? (
+              <div style={{ color: "var(--color-text)" }}>
+                <div>{getEventPrettyName(draftToDelete.eventId)}</div>
+                <div style={{ color: "var(--color-text-dark)" }}>
+                  {draftToDelete.draftSet}
+                  {draftToDelete.date
+                    ? ` · ${timeAgo(new Date(draftToDelete.date).getTime())}`
+                    : ""}
+                </div>
+              </div>
+            ) : (
+              <></>
+            )
+          }
+        />
+      </PopupComponent>
+    </Section>
   );
 }

--- a/src/components/views/drafts/DraftsHome.tsx
+++ b/src/components/views/drafts/DraftsHome.tsx
@@ -1,18 +1,31 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useSelector } from "react-redux";
+/* eslint-disable react/jsx-props-no-spreading */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
 import deleteDraft from "../../../data/deleteDraft";
 import { getData } from "../../../data/store";
+import usePagingControls from "../../../hooks/usePagingControls";
+import {
+  DateOption,
+  dateOptions,
+  selectCurrentFilterDate,
+  setDateOption,
+} from "../../../redux/slices/FilterSlice";
 import { AppState } from "../../../redux/stores/rendererStore";
 import { InternalDraftv2 } from "../../../types";
 import isElectron from "../../../utils/electron/isElectron";
 import getEventPrettyName from "../../../utils/getEventPrettyName";
 import getPopupClass from "../../../utils/getPopupClass";
 import timeAgo from "../../../utils/timeAgo";
+import InputContainer from "../../InputContainer";
+import PagingControls from "../../PagingControls";
 import PopupComponent from "../../PopupComponent";
 import ConfirmDialog from "../../popups/ConfirmDialog";
 import Section from "../../ui/Section";
+import Select from "../../ui/Select";
+import { MatchData } from "../history/convertDbMatchData";
 import ListItemDraft from "./ListItemDraft";
 
 interface DraftRecord {
@@ -20,16 +33,69 @@ interface DraftRecord {
   draft: InternalDraftv2;
 }
 
+interface DraftsHomeProps {
+  matchesData: MatchData[];
+  datePickerDoShow: () => void;
+}
+
 const voidFn = (): void => undefined;
 
-export default function DraftsHome() {
+const draftTypeNames: Record<string, string> = {
+  QuickDraft: "Quick Drafts",
+  PremierDraft: "Premier Drafts",
+  TradDraft: "Traditional Drafts",
+  CompDraft: "Competitive Drafts",
+  Sealed: "Sealed",
+};
+
+function draftTypeOf(eventId: string): string | null {
+  const type = Object.keys(draftTypeNames).find((t) =>
+    eventId.startsWith(`${t}_`)
+  );
+  return type ?? null;
+}
+
+/**
+ * The dropdown speaks three languages: "type:QuickDraft" (every quick draft),
+ * "set:MSH" (every draft of a set) and a bare eventId (one exact queue).
+ * Matches only carry the eventId, so the set test falls back to the "_MSH_"
+ * segment the queue names embed.
+ */
+function eventFilterFn(
+  filter: string
+): (eventId: string, draftSet?: string) => boolean {
+  if (!filter) return () => true;
+  if (filter.startsWith("type:")) {
+    const type = filter.slice("type:".length);
+    return (eventId) => eventId.startsWith(`${type}_`);
+  }
+  if (filter.startsWith("set:")) {
+    const set = filter.slice("set:".length);
+    return (eventId, draftSet) =>
+      draftSet ? draftSet === set : eventId.indexOf(`_${set}_`) !== -1;
+  }
+  return (eventId) => eventId === filter;
+}
+
+export default function DraftsHome(props: DraftsHomeProps) {
+  const { matchesData, datePickerDoShow } = props;
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const draftsIndex = useSelector(
     (state: AppState) => state.mainData.draftsIndex
   );
+  // Same date filter the matches tab uses — one "From" setting for the app.
+  const filterDate = useSelector(selectCurrentFilterDate);
+  const datePickerDate = useSelector(
+    (state: AppState) => state.filter.startDate
+  );
+  const fromDateOption = useSelector(
+    (state: AppState) => state.filter.dateOption
+  );
 
   const [records, setRecords] = useState<DraftRecord[]>([]);
+  const [eventFilter, setEventFilter] = useState("");
 
   const os = isElectron() ? process.platform : "";
   const openDeleteDraft = useRef<() => void>(voidFn);
@@ -68,71 +134,218 @@ export default function DraftsHome() {
     });
   }, [draftsIndex]);
 
-  return (
-    <Section
-      style={{
-        marginTop: "16px",
-        flexDirection: "column",
-        textAlign: "center",
-      }}
-    >
-      {records.length === 0 ? (
-        <>
-          <div className="wip-sign" />
-          <h1>No drafts yet</h1>
-          <p style={{ marginBottom: "16px" }}>
-            Your drafts are recorded as you make picks — start one in Arena and
-            it will show up here.
-          </p>
-        </>
-      ) : (
-        <div className="drafts-list">
-          {records.map((record) => (
-            <ListItemDraft
-              key={record.key}
-              draft={record.draft}
-              deleteCallback={askDeleteDraft}
-              onClick={() =>
-                history.push(`/drafts/${encodeURIComponent(record.key)}`)
-              }
-            />
-          ))}
-        </div>
-      )}
+  // Grouped options assembled from the drafts we actually have.
+  const eventOptions = useMemo(() => {
+    const types = new Set<string>();
+    const sets = new Set<string>();
+    const events = new Set<string>();
+    records.forEach(({ draft }) => {
+      const type = draftTypeOf(draft.eventId);
+      if (type) types.add(type);
+      if (draft.draftSet) sets.add(draft.draftSet);
+      events.add(draft.eventId);
+    });
+    const options = [""];
+    if (types.size > 0) {
+      options.push(
+        "%%Draft Types",
+        ...[...types].sort().map((t) => `type:${t}`)
+      );
+    }
+    if (sets.size > 0) {
+      options.push("%%Sets", ...[...sets].sort().map((s) => `set:${s}`));
+    }
+    options.push("%%Events", ...[...events].sort());
+    return options;
+  }, [records]);
 
-      <PopupComponent
-        open={false}
-        className={getPopupClass(os)}
-        width="480px"
-        height="auto"
-        openFnRef={openDeleteDraft}
-        closeFnRef={closeDeleteDraft}
-        persistent={false}
-        onClose={(): void => setDraftToDelete(null)}
+  const formatEventOption = useCallback((option: string) => {
+    if (option === "") return "All Drafts";
+    if (option.startsWith("type:")) {
+      const type = option.slice("type:".length);
+      return draftTypeNames[type] ?? type;
+    }
+    if (option.startsWith("set:")) return option.slice("set:".length);
+    return getEventPrettyName(option);
+  }, []);
+
+  const filteredRecords = useMemo(() => {
+    const matchesEvent = eventFilterFn(eventFilter);
+    const minTime = filterDate.getTime();
+    return records.filter(({ draft }) => {
+      const time = draft.date ? new Date(draft.date).getTime() : 0;
+      if (time < minTime) return false;
+      return matchesEvent(draft.eventId, draft.draftSet);
+    });
+  }, [records, eventFilter, filterDate]);
+
+  // Event winrate across the drafts on screen. Matches don't record which
+  // draft they came from, but they keep the queue's eventId — so every match
+  // in one of the filtered drafts' queues (inside the date window) counts.
+  const stats = useMemo(() => {
+    const eventIds = new Set(filteredRecords.map((r) => r.draft.eventId));
+    const minTime = filterDate.getTime();
+    let wins = 0;
+    let losses = 0;
+    matchesData.forEach((match) => {
+      if (!eventIds.has(match.eventId)) return;
+      if (match.timestamp < minTime) return;
+      if (match.win) wins += 1;
+      else losses += 1;
+    });
+    return { wins, losses, matches: wins + losses };
+  }, [filteredRecords, matchesData, filterDate]);
+
+  const pagingControlProps = usePagingControls(filteredRecords.length, 25);
+  const { pageIndex, pageCount, pageSize, gotoPage } = pagingControlProps;
+
+  // Deleting the last draft on the last page (or narrowing the filter) would
+  // otherwise leave us stranded on a page that no longer exists.
+  useEffect(() => {
+    if (pageIndex > 0 && pageIndex >= pageCount) {
+      gotoPage(Math.max(0, pageCount - 1));
+    }
+  }, [pageIndex, pageCount, gotoPage]);
+
+  const winrate =
+    stats.matches > 0 ? Math.round((stats.wins / stats.matches) * 100) : null;
+
+  return (
+    <>
+      <div className="FilterSection">
+        <Section style={{ marginTop: "16px", marginBottom: "16px" }}>
+          <Select
+            style={{ width: "280px" }}
+            options={eventOptions}
+            optionFormatter={formatEventOption}
+            current={eventFilter}
+            callback={setEventFilter}
+          />
+          <div style={{ lineHeight: "32px", marginLeft: "16px" }}>From:</div>
+          <InputContainer style={{ width: "auto" }} title="">
+            <input
+              onClick={datePickerDoShow}
+              style={{
+                backgroundColor: "var(--color-base)",
+                width: "140px",
+                cursor: "pointer",
+              }}
+              readOnly
+              type="date"
+              value={datePickerDate.toISOString().substring(0, 10)}
+            />
+          </InputContainer>
+          <Select
+            options={dateOptions}
+            current={fromDateOption}
+            callback={(opt: DateOption) => {
+              dispatch(setDateOption(opt));
+            }}
+          />
+        </Section>
+      </div>
+
+      <Section
+        style={{
+          marginBottom: "16px",
+          flexDirection: "column",
+          textAlign: "center",
+        }}
       >
-        <ConfirmDialog
-          title="Delete draft?"
-          danger
-          confirmText="Delete"
-          onConfirm={confirmDeleteDraft}
-          onClose={(): void => closeDeleteDraft.current()}
-          text={
-            draftToDelete ? (
-              <div style={{ color: "var(--color-text)" }}>
-                <div>{getEventPrettyName(draftToDelete.eventId)}</div>
-                <div style={{ color: "var(--color-text-dark)" }}>
-                  {draftToDelete.draftSet}
-                  {draftToDelete.date
-                    ? ` · ${timeAgo(new Date(draftToDelete.date).getTime())}`
-                    : ""}
+        {records.length === 0 ? (
+          <>
+            <div className="wip-sign" />
+            <h1>No drafts yet</h1>
+            <p style={{ marginBottom: "16px" }}>
+              Your drafts are recorded as you make picks — start one in Arena
+              and it will show up here.
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="drafts-stats-bar">
+              <div>
+                <span>{filteredRecords.length}</span>
+                {filteredRecords.length === 1 ? " draft" : " drafts"}
+              </div>
+              <div>
+                <span>{stats.matches}</span>
+                {stats.matches === 1 ? " match" : " matches"}
+              </div>
+              <div>
+                <span>{`${stats.wins} - ${stats.losses}`}</span>
+              </div>
+              {winrate !== null && (
+                <div>
+                  <span>{`${winrate}%`}</span> winrate
+                </div>
+              )}
+            </div>
+            {filteredRecords.length === 0 ? (
+              <p style={{ margin: "16px 0" }}>
+                No drafts match the current filters.
+              </p>
+            ) : (
+              <div className="drafts-list">
+                {filteredRecords
+                  .slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
+                  .map((record) => (
+                    <ListItemDraft
+                      key={record.key}
+                      draft={record.draft}
+                      deleteCallback={askDeleteDraft}
+                      onClick={() =>
+                        history.push(
+                          `/drafts/${encodeURIComponent(record.key)}`
+                        )
+                      }
+                    />
+                  ))}
+                <div style={{ marginTop: "10px" }}>
+                  <PagingControls
+                    {...pagingControlProps}
+                    pageSizeOptions={[10, 25, 50, 100]}
+                  />
                 </div>
               </div>
-            ) : (
-              <></>
-            )
-          }
-        />
-      </PopupComponent>
-    </Section>
+            )}
+          </>
+        )}
+
+        <PopupComponent
+          open={false}
+          className={getPopupClass(os)}
+          width="480px"
+          height="auto"
+          openFnRef={openDeleteDraft}
+          closeFnRef={closeDeleteDraft}
+          persistent={false}
+          onClose={(): void => setDraftToDelete(null)}
+        >
+          <ConfirmDialog
+            title="Delete draft?"
+            danger
+            confirmText="Delete"
+            onConfirm={confirmDeleteDraft}
+            onClose={(): void => closeDeleteDraft.current()}
+            text={
+              draftToDelete ? (
+                <div style={{ color: "var(--color-text)" }}>
+                  <div>{getEventPrettyName(draftToDelete.eventId)}</div>
+                  <div style={{ color: "var(--color-text-dark)" }}>
+                    {draftToDelete.draftSet}
+                    {draftToDelete.date
+                      ? ` · ${timeAgo(new Date(draftToDelete.date).getTime())}`
+                      : ""}
+                  </div>
+                </div>
+              ) : (
+                <></>
+              )
+            }
+          />
+        </PopupComponent>
+      </Section>
+    </>
   );
 }

--- a/src/components/views/drafts/ListItemDraft.tsx
+++ b/src/components/views/drafts/ListItemDraft.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+
+import { DEFAULT_TILE } from "../../../constants";
+import { useCards } from "../../../hooks/useCard";
+import { InternalDraftv2 } from "../../../types";
+import getEventPrettyName from "../../../utils/getEventPrettyName";
+import Colors from "../../../utils/mtga/colors";
+import timeAgo from "../../../utils/timeAgo";
+import {
+  Column,
+  DeleteButton,
+  FlexBottom,
+  FlexTop,
+  HoverTile,
+  ListItem,
+} from "../../ListItem";
+import ManaCost from "../../ManaCost";
+
+interface ListItemDraftProps {
+  draft: InternalDraftv2;
+  onClick: () => void;
+  deleteCallback?: (draft: InternalDraftv2) => void;
+}
+
+export default function ListItemDraft(props: ListItemDraftProps): JSX.Element {
+  const { draft, onClick, deleteCallback } = props;
+
+  const timestamp = draft.date ? new Date(draft.date).getTime() : 0;
+
+  // Colors of the submitted deck only — the pool is close to five-colour by
+  // nature, which says nothing about what was actually built.
+  const deckIds = useMemo(
+    () =>
+      (draft.deckMain ?? [])
+        .map((c) => c.id)
+        .filter((id, i, all) => all.indexOf(id) === i),
+    [draft]
+  );
+  const cards = useCards(deckIds);
+  const colorList = useMemo(() => {
+    const colors = new Colors();
+    cards.forEach((card) => {
+      if (card?.ManaCost) colors.addFromCost(card.ManaCost);
+    });
+    return colors.get();
+  }, [cards]);
+
+  return (
+    <ListItem click={onClick}>
+      <div
+        className="list-item-left-indicator"
+        style={{ backgroundColor: "var(--color-section-active)" }}
+      />
+      <HoverTile grpId={draft.pickedCards[0] || DEFAULT_TILE} />
+      <Column className="list-item-left">
+        <FlexTop>
+          <div className="list-deck-name">
+            {getEventPrettyName(draft.eventId)}
+          </div>
+          <div className="list-deck-name-it">{draft.draftSet}</div>
+        </FlexTop>
+        <FlexBottom>
+          {colorList.length > 0 && (
+            <ManaCost className="mana-s20" colors={colorList} />
+          )}
+          <div
+            style={{ lineHeight: "30px", marginLeft: "4px" }}
+            className="list-match-time"
+          >
+            {timestamp ? <div className="time">{timeAgo(timestamp)}</div> : ""}
+          </div>
+        </FlexBottom>
+      </Column>
+      <Column className="list-item-center">
+        <></>
+      </Column>
+      <Column className="list-item-right">
+        <FlexTop>
+          <div className="list-match-title" style={{ opacity: 0.7 }}>
+            {draft.deckMain ? "Deck submitted" : "No deck"}
+          </div>
+        </FlexTop>
+        <FlexBottom>
+          <></>
+        </FlexBottom>
+      </Column>
+      {deleteCallback && draft.id && (
+        <DeleteButton
+          dataId={draft.id}
+          title="Delete draft"
+          deleteCallback={() => deleteCallback(draft)}
+        />
+      )}
+    </ListItem>
+  );
+}

--- a/src/components/views/drafts/ViewDrafts.tsx
+++ b/src/components/views/drafts/ViewDrafts.tsx
@@ -1,10 +1,17 @@
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 
 import useIsLoggedIn from "../../../hooks/useIsLoggedIn";
+import { MatchData } from "../history/convertDbMatchData";
 import DraftsHome from "./DraftsHome";
 import DraftView from "./DraftView";
 
-export default function ViewDrafts() {
+interface ViewDraftsProps {
+  matchesData: MatchData[];
+  datePickerDoShow: () => void;
+}
+
+export default function ViewDrafts(props: ViewDraftsProps) {
+  const { matchesData, datePickerDoShow } = props;
   const { url } = useRouteMatch();
   const loggedIn = useIsLoggedIn();
 
@@ -15,7 +22,16 @@ export default function ViewDrafts() {
       {loggedIn && (
         <Switch>
           <Route exact path={`${url}/:id`} component={DraftView} />
-          <Route exact path={`${url}/`} component={DraftsHome} />
+          <Route
+            exact
+            path={`${url}/`}
+            render={() => (
+              <DraftsHome
+                matchesData={matchesData}
+                datePickerDoShow={datePickerDoShow}
+              />
+            )}
+          />
         </Switch>
       )}
     </>

--- a/src/components/views/drafts/ViewDrafts.tsx
+++ b/src/components/views/drafts/ViewDrafts.tsx
@@ -1,26 +1,23 @@
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 
 import useIsLoggedIn from "../../../hooks/useIsLoggedIn";
-import Section from "../../ui/Section";
 import DraftsHome from "./DraftsHome";
+import DraftView from "./DraftView";
 
 export default function ViewDrafts() {
   const { url } = useRouteMatch();
   const loggedIn = useIsLoggedIn();
 
+  // No shared Section here: the list wraps itself, and the replay view lays
+  // out its own header/pack/picked sections.
   return (
-    <Section
-      style={{
-        marginTop: "16px",
-        flexDirection: "column",
-        textAlign: "center",
-      }}
-    >
+    <>
       {loggedIn && (
         <Switch>
+          <Route exact path={`${url}/:id`} component={DraftView} />
           <Route exact path={`${url}/`} component={DraftsHome} />
         </Switch>
       )}
-    </Section>
+    </>
   );
 }

--- a/src/components/views/settings/OverlaySettingsPanel.tsx
+++ b/src/components/views/settings/OverlaySettingsPanel.tsx
@@ -278,6 +278,14 @@ function OverlaySettingsSection(props: SectionProps): JSX.Element {
         disabled={OVERLAY_DRAFT_MODES.includes(settings.mode)}
       />
       <Toggle
+        text="Show draft stats"
+        value={settings.draftStats}
+        callback={(val: boolean): void =>
+          saveOverlaySettings(current, { draftStats: val })
+        }
+        disabled={!OVERLAY_DRAFT_MODES.includes(settings.mode)}
+      />
+      <Toggle
         text="Show odds"
         value={settings.drawOdds}
         callback={(val: boolean): void =>

--- a/src/components/views/timeline/ViewTimeline.tsx
+++ b/src/components/views/timeline/ViewTimeline.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 
 import { useCardArtCrop } from "../../../hooks/useCardImage";
 import { AppState } from "../../../redux/stores/rendererStore";
+import isLimitedEventId from "../../../utils/isLimitedEventId";
 import Section from "../../ui/Section";
 import { MatchData } from "../history/convertDbMatchData";
 
@@ -512,55 +513,87 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
 
     const deckBands = bandsFor(matches.map(deckNameOf));
 
+    const seasonList = Object.values(seasons)
+      .filter((s) => s.start > 0)
+      .sort((a, b) => a.start - b.start);
+
     // Rank ladder over the matches that carry a rank, plus a badge each time
-    // the rank class advances, plus deck bands in rank-series index space.
-    const rankSeries: Pt[] = [];
-    const rankDeckNames: string[] = [];
-    const rankUps: Marker[] = [];
-    let prevCls: number | null = null;
-    let prevTierIdx: number | null = null;
-    matches.forEach((m) => {
-      const player = m.internalMatch?.player;
-      const s = rankScore(player);
-      const cls = matchClass(player);
-      if (s === null || cls === null) return;
-      // Tier is 4..1 (1 = highest); index it so bigger = better. Mythic has no
-      // tiers — treat it as above every tier.
-      const tier =
-        typeof (player as any)?.tier === "number"
-          ? ((player as any).tier as number)
-          : null;
-      const tierIdx = cls >= 6 ? 99 : 4 - (tier ?? 4);
+    // the rank class advances, plus deck bands and season dividers in
+    // rank-series index space. Built per format: Constructed and Limited are
+    // separate ladders, so their matches must never share a line.
+    const buildRankChart = (ms: MatchData[]) => {
+      const series: Pt[] = [];
+      const deckNames: string[] = [];
+      const timestamps: number[] = [];
+      const ups: Marker[] = [];
+      let prevCls: number | null = null;
+      let prevTierIdx: number | null = null;
+      ms.forEach((m) => {
+        const player = m.internalMatch?.player;
+        const s = rankScore(player);
+        const cls = matchClass(player);
+        if (s === null || cls === null) return;
+        // Tier is 4..1 (1 = highest); index it so bigger = better. Mythic has
+        // no tiers — treat it as above every tier.
+        const tier =
+          typeof (player as any)?.tier === "number"
+            ? ((player as any).tier as number)
+            : null;
+        const tierIdx = cls >= 6 ? 99 : 4 - (tier ?? 4);
 
-      const idx = rankSeries.length;
-      rankSeries.push({ x: idx, y: s });
-      rankDeckNames.push(deckNameOf(m));
+        const idx = series.length;
+        series.push({ x: idx, y: s });
+        deckNames.push(deckNameOf(m));
+        timestamps.push(m.timestamp);
 
-      // Badge every advance: a new class (Bronze -> Silver) or a new tier
-      // within the class (Bronze 2 -> Bronze 1). Rank is captured at match
-      // start, so the badge lands on the first match played AT the new rank.
-      const classUp = prevCls !== null && cls > prevCls;
-      const tierUp =
-        prevCls !== null &&
-        cls === prevCls &&
-        prevTierIdx !== null &&
-        tierIdx > prevTierIdx;
-      if (classUp || tierUp) {
-        const name = RANK_META[cls]?.name || "?";
-        const tierLabel = cls >= 6 || tier === null ? "" : ` ${tier}`;
-        rankUps.push({
+        // Badge every advance: a new class (Bronze -> Silver) or a new tier
+        // within the class (Bronze 2 -> Bronze 1). Rank is captured at match
+        // start, so the badge lands on the first match played AT the new rank.
+        const classUp = prevCls !== null && cls > prevCls;
+        const tierUp =
+          prevCls !== null &&
+          cls === prevCls &&
+          prevTierIdx !== null &&
+          tierIdx > prevTierIdx;
+        if (classUp || tierUp) {
+          const name = RANK_META[cls]?.name || "?";
+          const tierLabel = cls >= 6 || tier === null ? "" : ` ${tier}`;
+          ups.push({
+            i: idx,
+            v: s,
+            node: <RankBadge cls={cls} tier={tier ?? undefined} />,
+            title: `Ranked up to ${name}${tierLabel} · ${new Date(
+              m.timestamp
+            ).toLocaleDateString()}`,
+          });
+        }
+        prevCls = cls;
+        prevTierIdx = tierIdx;
+      });
+
+      const dividers: Divider[] = seasonList
+        .map((season) => ({
+          season,
+          idx: timestamps.findIndex((t) => t >= season.start),
+        }))
+        .filter(({ idx }) => idx > 0)
+        .map(({ season, idx }) => ({
           i: idx,
-          v: s,
-          node: <RankBadge cls={cls} tier={tier ?? undefined} />,
-          title: `Ranked up to ${name}${tierLabel} · ${new Date(
-            m.timestamp
-          ).toLocaleDateString()}`,
-        });
-      }
-      prevCls = cls;
-      prevTierIdx = tierIdx;
-    });
-    const rankBands = bandsFor(rankDeckNames);
+          label: `Season ${season.ordinal}`,
+          title: `Season ${season.ordinal} started ${new Date(
+            season.start
+          ).toLocaleString()}`,
+        }));
+
+      return { series, ups, bands: bandsFor(deckNames), dividers };
+    };
+
+    const constructedRank = buildRankChart(
+      matches.filter((m) => !isLimitedEventId(m.eventId))
+    );
+    const limitedRank = buildRankChart(
+      matches.filter((m) => isLimitedEventId(m.eventId))
+    );
 
     // Current streak (from most recent).
     let streak = 0;
@@ -579,9 +612,7 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
     // to key off, and a rank drop can't be used either (losing a tier looks the
     // same). Seasons only appear here once the client has reported them, so
     // older boundaries are simply absent rather than guessed at.
-    const seasonDividers: Divider[] = Object.values(seasons)
-      .filter((s) => s.start > 0)
-      .sort((a, b) => a.start - b.start)
+    const seasonDividers: Divider[] = seasonList
       .map((s) => {
         const idx = matches.findIndex((m) => m.timestamp >= s.start);
         return { season: s, idx };
@@ -602,10 +633,9 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
       losses,
       winrate: total ? (wins / total) * 100 : 0,
       winrateSeries,
-      rankSeries,
-      rankUps,
+      constructedRank,
+      limitedRank,
       deckBands,
-      rankBands,
       seasonDividers,
       decks,
       deckMap,
@@ -686,44 +716,66 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
             />
           </Section>
 
-          <Section
-            style={{
-              margin: "0 0 16px",
-              padding: "16px",
-              flexDirection: "column",
-            }}
-          >
-            <div className="separator-title">Rank progression</div>
-            {data.rankSeries.length > 0 ? (
-              <LineChart
-                points={data.rankSeries}
-                color="var(--color-text-link)"
-                min={0}
-                max={rankMax}
-                bands={data.rankBands}
-                dividers={data.seasonDividers}
-                activeDeck={hoveredDeck}
-                onBandHover={setHoveredDeck}
-                yTicks={[1, 2, 3, 4, 5, 6].map((cls) => ({
-                  v: cls * 24,
-                  label: RANK_META[cls].name,
-                }))}
-                markers={data.rankUps}
-              />
-            ) : (
-              <div
+          {/* Constructed and Limited are separate ladders with separate
+              ranks, so each gets its own chart. */}
+          {[
+            {
+              title: "Rank progression — Constructed",
+              rank: data.constructedRank,
+            },
+            { title: "Rank progression — Limited", rank: data.limitedRank },
+          ]
+            .filter(({ rank }) => rank.series.length > 0)
+            .map(({ title, rank }) => (
+              <Section
+                key={title}
                 style={{
-                  padding: "24px",
-                  textAlign: "center",
-                  color: "var(--color-text-dark)",
+                  margin: "0 0 16px",
+                  padding: "16px",
+                  flexDirection: "column",
                 }}
               >
-                Play ranked matches to see your rank climb here, with a badge
-                each time you advance a rank. (Rank is captured per match going
-                forward.)
-              </div>
+                <div className="separator-title">{title}</div>
+                <LineChart
+                  points={rank.series}
+                  color="var(--color-text-link)"
+                  min={0}
+                  max={rankMax}
+                  bands={rank.bands}
+                  dividers={rank.dividers}
+                  activeDeck={hoveredDeck}
+                  onBandHover={setHoveredDeck}
+                  yTicks={[1, 2, 3, 4, 5, 6].map((cls) => ({
+                    v: cls * 24,
+                    label: RANK_META[cls].name,
+                  }))}
+                  markers={rank.ups}
+                />
+              </Section>
+            ))}
+          {data.constructedRank.series.length === 0 &&
+            data.limitedRank.series.length === 0 && (
+              <Section
+                style={{
+                  margin: "0 0 16px",
+                  padding: "16px",
+                  flexDirection: "column",
+                }}
+              >
+                <div className="separator-title">Rank progression</div>
+                <div
+                  style={{
+                    padding: "24px",
+                    textAlign: "center",
+                    color: "var(--color-text-dark)",
+                  }}
+                >
+                  Play ranked matches to see your rank climb here, with a badge
+                  each time you advance a rank. (Rank is captured per match
+                  going forward.)
+                </div>
+              </Section>
             )}
-          </Section>
 
           {data.decks.length > 0 && (
             <Section

--- a/src/components/views/timeline/ViewTimeline.tsx
+++ b/src/components/views/timeline/ViewTimeline.tsx
@@ -429,6 +429,56 @@ function DeckPanel({ deck }: { deck?: DeckStat }): JSX.Element {
   );
 }
 
+type TimelineFormat = "constructed" | "limited";
+
+// Constructed | Limited segmented switch — the two ladders share nothing, so
+// the whole tab shows one format at a time.
+function FormatToggle({
+  format,
+  onChange,
+}: {
+  format: TimelineFormat;
+  onChange: (format: TimelineFormat) => void;
+}): JSX.Element {
+  const options: [TimelineFormat, string][] = [
+    ["constructed", "Constructed"],
+    ["limited", "Limited"],
+  ];
+  return (
+    <div
+      style={{
+        display: "flex",
+        margin: "0 auto",
+        background: "var(--color-base)",
+        borderRadius: "16px",
+        padding: "3px",
+        gap: "2px",
+      }}
+    >
+      {options.map(([key, label]) => (
+        <div
+          key={key}
+          onClick={() => onChange(key)}
+          style={{
+            padding: "4px 18px",
+            borderRadius: "13px",
+            cursor: "pointer",
+            userSelect: "none",
+            fontSize: "14px",
+            background:
+              format === key ? "var(--color-section-active)" : "transparent",
+            color:
+              format === key ? "var(--color-text)" : "var(--color-text-dark)",
+            transition: "background 0.15s ease-in-out",
+          }}
+        >
+          {label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface ViewTimelineProps {
   matchesData: MatchData[];
 }
@@ -436,12 +486,19 @@ interface ViewTimelineProps {
 export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
   const { matchesData } = props;
   const [hoveredDeck, setHoveredDeck] = useState<string | null>(null);
+  const [format, setFormat] = useState<TimelineFormat>("constructed");
   const seasons = useSelector((state: AppState) => state.mainData.seasons);
 
+  const switchFormat = (next: TimelineFormat): void => {
+    setFormat(next);
+    // The hovered deck belongs to the format we're leaving.
+    setHoveredDeck(null);
+  };
+
   const data = useMemo(() => {
-    const matches = [...(matchesData || [])].sort(
-      (a, b) => a.timestamp - b.timestamp
-    );
+    const matches = (matchesData || [])
+      .filter((m) => (format === "limited") === isLimitedEventId(m.eventId))
+      .sort((a, b) => a.timestamp - b.timestamp);
 
     const total = matches.length;
     const wins = matches.filter((m) => m.win).length;
@@ -519,8 +576,8 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
 
     // Rank ladder over the matches that carry a rank, plus a badge each time
     // the rank class advances, plus deck bands and season dividers in
-    // rank-series index space. Built per format: Constructed and Limited are
-    // separate ladders, so their matches must never share a line.
+    // rank-series index space. The tab is already scoped to one format, so
+    // this never mixes the Constructed and Limited ladders.
     const buildRankChart = (ms: MatchData[]) => {
       const series: Pt[] = [];
       const deckNames: string[] = [];
@@ -588,12 +645,7 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
       return { series, ups, bands: bandsFor(deckNames), dividers };
     };
 
-    const constructedRank = buildRankChart(
-      matches.filter((m) => !isLimitedEventId(m.eventId))
-    );
-    const limitedRank = buildRankChart(
-      matches.filter((m) => isLimitedEventId(m.eventId))
-    );
+    const rank = buildRankChart(matches);
 
     // Current streak (from most recent).
     let streak = 0;
@@ -633,8 +685,7 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
       losses,
       winrate: total ? (wins / total) * 100 : 0,
       winrateSeries,
-      constructedRank,
-      limitedRank,
+      rank,
       deckBands,
       seasonDividers,
       decks,
@@ -642,9 +693,9 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
       streak,
       streakWin,
     };
-  }, [matchesData, seasons]);
+  }, [matchesData, seasons, format]);
 
-  if (data.total === 0) {
+  if ((matchesData || []).length === 0) {
     return (
       <Section style={{ margin: "24px 16px", justifyContent: "center" }}>
         <div style={{ padding: "48px", color: "var(--color-text-dark)" }}>
@@ -660,109 +711,115 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
 
   return (
     <div style={{ padding: "0 16px" }}>
-      {/* Full-width summary header */}
+      {/* Full-width summary header, scoped (like everything below it) to the
+          selected format. */}
       <Section
         style={{
           margin: "16px 0",
           padding: "20px",
-          justifyContent: "space-around",
-          flexWrap: "wrap",
+          flexDirection: "column",
           gap: "16px",
         }}
       >
-        <Stat label="Matches" value={`${data.total}`} />
-        <Stat
-          label="Win rate"
-          value={`${data.winrate.toFixed(1)}%`}
-          color={data.winrate >= 50 ? "var(--color-g)" : "var(--color-r)"}
-        />
-        <Stat label="Record" value={`${data.wins}-${data.losses}`} />
-        <Stat
-          label={data.streakWin ? "Win streak" : "Loss streak"}
-          value={`${data.streak}`}
-          color={data.streakWin ? "var(--color-g)" : "var(--color-r)"}
-        />
+        <FormatToggle format={format} onChange={switchFormat} />
+        {data.total > 0 ? (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-around",
+              flexWrap: "wrap",
+              gap: "16px",
+              width: "100%",
+            }}
+          >
+            <Stat label="Matches" value={`${data.total}`} />
+            <Stat
+              label="Win rate"
+              value={`${data.winrate.toFixed(1)}%`}
+              color={data.winrate >= 50 ? "var(--color-g)" : "var(--color-r)"}
+            />
+            <Stat label="Record" value={`${data.wins}-${data.losses}`} />
+            <Stat
+              label={data.streakWin ? "Win streak" : "Loss streak"}
+              value={`${data.streak}`}
+              color={data.streakWin ? "var(--color-g)" : "var(--color-r)"}
+            />
+          </div>
+        ) : (
+          <div
+            style={{
+              padding: "16px",
+              textAlign: "center",
+              color: "var(--color-text-dark)",
+            }}
+          >
+            {`No ${
+              format === "limited" ? "Limited" : "Constructed"
+            } matches yet.`}
+          </div>
+        )}
       </Section>
 
       {/* Graphs (left) + deck detail (right) */}
-      <div style={{ display: "flex", gap: "16px", alignItems: "flex-start" }}>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <Section
-            style={{
-              margin: "0 0 16px",
-              padding: "16px",
-              flexDirection: "column",
-            }}
-          >
-            <div className="separator-title">Win rate over time</div>
-            <div style={{ fontSize: "12px", color: "var(--color-text-dark)" }}>
-              Background bands show the deck played across each stretch — hover
-              for its stats.
-            </div>
-            <LineChart
-              points={data.winrateSeries}
-              color="var(--color-g)"
-              min={0}
-              max={100}
-              bands={data.deckBands}
-              dividers={data.seasonDividers}
-              activeDeck={hoveredDeck}
-              onBandHover={setHoveredDeck}
-              yTicks={[
-                { v: 0, label: "0%" },
-                { v: 50, label: "50%" },
-                { v: 100, label: "100%" },
-              ]}
-            />
-          </Section>
-
-          {/* Constructed and Limited are separate ladders with separate
-              ranks, so each gets its own chart. */}
-          {[
-            {
-              title: "Rank progression — Constructed",
-              rank: data.constructedRank,
-            },
-            { title: "Rank progression — Limited", rank: data.limitedRank },
-          ]
-            .filter(({ rank }) => rank.series.length > 0)
-            .map(({ title, rank }) => (
-              <Section
-                key={title}
-                style={{
-                  margin: "0 0 16px",
-                  padding: "16px",
-                  flexDirection: "column",
-                }}
+      {data.total > 0 && (
+        <div style={{ display: "flex", gap: "16px", alignItems: "flex-start" }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Section
+              style={{
+                margin: "0 0 16px",
+                padding: "16px",
+                flexDirection: "column",
+              }}
+            >
+              <div className="separator-title">Win rate over time</div>
+              <div
+                style={{ fontSize: "12px", color: "var(--color-text-dark)" }}
               >
-                <div className="separator-title">{title}</div>
+                Background bands show the deck played across each stretch —
+                hover for its stats.
+              </div>
+              <LineChart
+                points={data.winrateSeries}
+                color="var(--color-g)"
+                min={0}
+                max={100}
+                bands={data.deckBands}
+                dividers={data.seasonDividers}
+                activeDeck={hoveredDeck}
+                onBandHover={setHoveredDeck}
+                yTicks={[
+                  { v: 0, label: "0%" },
+                  { v: 50, label: "50%" },
+                  { v: 100, label: "100%" },
+                ]}
+              />
+            </Section>
+
+            <Section
+              style={{
+                margin: "0 0 16px",
+                padding: "16px",
+                flexDirection: "column",
+              }}
+            >
+              <div className="separator-title">Rank progression</div>
+              {data.rank.series.length > 0 ? (
                 <LineChart
-                  points={rank.series}
+                  points={data.rank.series}
                   color="var(--color-text-link)"
                   min={0}
                   max={rankMax}
-                  bands={rank.bands}
-                  dividers={rank.dividers}
+                  bands={data.rank.bands}
+                  dividers={data.rank.dividers}
                   activeDeck={hoveredDeck}
                   onBandHover={setHoveredDeck}
                   yTicks={[1, 2, 3, 4, 5, 6].map((cls) => ({
                     v: cls * 24,
                     label: RANK_META[cls].name,
                   }))}
-                  markers={rank.ups}
+                  markers={data.rank.ups}
                 />
-              </Section>
-            ))}
-          {data.constructedRank.series.length === 0 &&
-            data.limitedRank.series.length === 0 && (
-              <Section
-                style={{
-                  margin: "0 0 16px",
-                  padding: "16px",
-                  flexDirection: "column",
-                }}
-              >
-                <div className="separator-title">Rank progression</div>
+              ) : (
                 <div
                   style={{
                     padding: "24px",
@@ -774,89 +831,90 @@ export default function ViewTimeline(props: ViewTimelineProps): JSX.Element {
                   each time you advance a rank. (Rank is captured per match
                   going forward.)
                 </div>
-              </Section>
-            )}
+              )}
+            </Section>
 
-          {data.decks.length > 0 && (
-            <Section
-              style={{
-                margin: "0 0 24px",
-                padding: "16px",
-                flexDirection: "column",
-              }}
-            >
-              <div className="separator-title">Decks played</div>
-              <div
+            {data.decks.length > 0 && (
+              <Section
                 style={{
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: "8px 20px",
-                  marginTop: "10px",
+                  margin: "0 0 24px",
+                  padding: "16px",
+                  flexDirection: "column",
                 }}
               >
-                {data.decks.map((d) => {
-                  const wr = d.games ? (d.wins / d.games) * 100 : 0;
-                  return (
-                    <div
-                      key={d.name}
-                      onMouseEnter={() => setHoveredDeck(d.name)}
-                      onMouseLeave={() => setHoveredDeck(null)}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
-                        cursor: "pointer",
-                        opacity:
-                          hoveredDeck && hoveredDeck !== d.name ? 0.5 : 1,
-                      }}
-                    >
-                      <span
+                <div className="separator-title">Decks played</div>
+                <div
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: "8px 20px",
+                    marginTop: "10px",
+                  }}
+                >
+                  {data.decks.map((d) => {
+                    const wr = d.games ? (d.wins / d.games) * 100 : 0;
+                    return (
+                      <div
+                        key={d.name}
+                        onMouseEnter={() => setHoveredDeck(d.name)}
+                        onMouseLeave={() => setHoveredDeck(null)}
                         style={{
-                          width: "12px",
-                          height: "12px",
-                          borderRadius: "3px",
-                          background: d.color,
-                          flexShrink: 0,
-                        }}
-                      />
-                      <span style={{ color: "var(--color-text)" }}>
-                        {d.name}
-                      </span>
-                      <span
-                        style={{
-                          color: "var(--color-text-dark)",
-                          fontSize: "13px",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "8px",
+                          cursor: "pointer",
+                          opacity:
+                            hoveredDeck && hoveredDeck !== d.name ? 0.5 : 1,
                         }}
                       >
-                        {d.wins}-{d.games - d.wins} ({wr.toFixed(0)}%)
-                      </span>
-                    </div>
-                  );
-                })}
+                        <span
+                          style={{
+                            width: "12px",
+                            height: "12px",
+                            borderRadius: "3px",
+                            background: d.color,
+                            flexShrink: 0,
+                          }}
+                        />
+                        <span style={{ color: "var(--color-text)" }}>
+                          {d.name}
+                        </span>
+                        <span
+                          style={{
+                            color: "var(--color-text-dark)",
+                            fontSize: "13px",
+                          }}
+                        >
+                          {d.wins}-{d.games - d.wins} ({wr.toFixed(0)}%)
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Section>
+            )}
+          </div>
+
+          <div style={{ width: "260px", flexShrink: 0 }}>
+            <Section
+              style={{
+                margin: 0,
+                padding: "16px",
+                flexDirection: "column",
+                position: "sticky",
+                top: "16px",
+              }}
+            >
+              <div className="separator-title">
+                {hoveredDeck ? "Deck" : "Top deck"}
+              </div>
+              <div style={{ marginTop: "10px" }}>
+                <DeckPanel deck={panelDeck} />
               </div>
             </Section>
-          )}
+          </div>
         </div>
-
-        <div style={{ width: "260px", flexShrink: 0 }}>
-          <Section
-            style={{
-              margin: 0,
-              padding: "16px",
-              flexDirection: "column",
-              position: "sticky",
-              top: "16px",
-            }}
-          >
-            <div className="separator-title">
-              {hoveredDeck ? "Deck" : "Top deck"}
-            </div>
-            <div style={{ marginTop: "10px" }}>
-              <DeckPanel deck={panelDeck} />
-            </div>
-          </Section>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/data/cloudSync.ts
+++ b/src/data/cloudSync.ts
@@ -13,7 +13,7 @@
  * first (`upsertArenaAccount`) before any dependent row.
  */
 import { CombinedRankInfo } from "../background/onLabel/InEventGetCombinedRankInfo";
-import { Cards } from "../types";
+import { Cards, InternalDraftv2 } from "../types";
 import { DbInventoryInfo, DbMatch } from "../types/dbTypes";
 import { ReaderDeck } from "../utils/mtgaReader";
 import { Database, Json } from "./database.types";
@@ -154,6 +154,40 @@ export async function pushMatch(arenaId: string, m: DbMatch): Promise<boolean> {
   }
 }
 
+/** Mirror a finished draft to Supabase. Same contract as pushMatch. */
+export async function pushDraft(
+  arenaId: string,
+  draft: InternalDraftv2
+): Promise<boolean> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId || !arenaId || !draft?.id) return false;
+    if (!(await upsertArenaAccount(userId, arenaId))) return false;
+
+    const row: Tables["drafts"]["Insert"] = {
+      user_id: userId,
+      arena_id: arenaId,
+      draft_id: draft.id,
+      event_id: draft.eventId || null,
+      draft_set: draft.draftSet || null,
+      played_at: draft.date ? new Date(draft.date).toISOString() : null,
+      deck_id: draft.deckId ?? null,
+      internal_draft: asJson(draft),
+    };
+    const { error } = await supabase
+      .from("drafts")
+      .upsert(row, { onConflict: "user_id,draft_id" });
+    if (error) {
+      console.error("[cloudSync] pushDraft:", error.message);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error("[cloudSync] pushDraft threw:", e);
+    return false;
+  }
+}
+
 /**
  * Remove a match from Supabase. RLS already scopes `matches` to auth.uid(), so
  * matching on match_id alone can only ever hit the current user's own row.
@@ -203,6 +237,70 @@ export async function pushDeletedMatch(matchId: string): Promise<boolean> {
   } catch (e) {
     console.error("[cloudSync] pushDeletedMatch threw:", e);
     return false;
+  }
+}
+
+/**
+ * Remove a draft from Supabase. RLS scopes `drafts` to auth.uid(), so matching
+ * on draft_id alone can only hit the current user's own row.
+ */
+export async function deleteRemoteDraft(draftId: string): Promise<boolean> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId || !draftId) return false;
+    const { error } = await supabase
+      .from("drafts")
+      .delete()
+      .eq("draft_id", draftId);
+    if (error) {
+      console.error("[cloudSync] deleteRemoteDraft:", error.message);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error("[cloudSync] deleteRemoteDraft threw:", e);
+    return false;
+  }
+}
+
+/** Record a draft deletion for other devices — same contract as pushDeletedMatch. */
+export async function pushDeletedDraft(draftId: string): Promise<boolean> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId || !draftId) return false;
+    const { error } = await supabase
+      .from("deleted_drafts")
+      .upsert(
+        { user_id: userId, draft_id: draftId },
+        { onConflict: "user_id,draft_id" }
+      );
+    if (error) {
+      console.error("[cloudSync] pushDeletedDraft:", error.message);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error("[cloudSync] pushDeletedDraft threw:", e);
+    return false;
+  }
+}
+
+/** Draft ids this account has deleted anywhere. Empty offline or on error. */
+export async function fetchDeletedDraftIds(): Promise<Set<string>> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId) return new Set();
+    const { data, error } = await supabase
+      .from("deleted_drafts")
+      .select("draft_id");
+    if (error) {
+      console.error("[cloudSync] fetchDeletedDraftIds:", error.message);
+      return new Set();
+    }
+    return new Set((data ?? []).map((r) => r.draft_id));
+  } catch (e) {
+    console.error("[cloudSync] fetchDeletedDraftIds threw:", e);
+    return new Set();
   }
 }
 

--- a/src/data/database.types.ts
+++ b/src/data/database.types.ts
@@ -233,6 +233,68 @@ export type Database = {
           }
         ];
       };
+      deleted_drafts: {
+        Row: {
+          deleted_at: string;
+          draft_id: string;
+          user_id: string;
+        };
+        Insert: {
+          deleted_at?: string;
+          draft_id: string;
+          user_id: string;
+        };
+        Update: {
+          deleted_at?: string;
+          draft_id?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      drafts: {
+        Row: {
+          arena_id: string;
+          created_at: string;
+          deck_id: string | null;
+          draft_id: string;
+          draft_set: string | null;
+          event_id: string | null;
+          internal_draft: Json;
+          played_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          arena_id: string;
+          created_at?: string;
+          deck_id?: string | null;
+          draft_id: string;
+          draft_set?: string | null;
+          event_id?: string | null;
+          internal_draft: Json;
+          played_at?: string | null;
+          user_id?: string;
+        };
+        Update: {
+          arena_id?: string;
+          created_at?: string;
+          deck_id?: string | null;
+          draft_id?: string;
+          draft_set?: string | null;
+          event_id?: string | null;
+          internal_draft?: Json;
+          played_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "drafts_user_id_arena_id_fkey";
+            columns: ["user_id", "arena_id"];
+            isOneToOne: false;
+            referencedRelation: "arena_accounts";
+            referencedColumns: ["user_id", "arena_id"];
+          }
+        ];
+      };
       matches: {
         Row: {
           arena_id: string;

--- a/src/data/deleteDraft.ts
+++ b/src/data/deleteDraft.ts
@@ -1,0 +1,34 @@
+/**
+ * Delete a draft everywhere it lives: the local KV, the in-memory index, the
+ * Redux index the drafts list reads, and Supabase — deleteMatch's shape.
+ *
+ * The tombstone is written first so a hydrate or sync racing this call can't
+ * put the draft back, and so the delete survives an offline cloud (syncDrafts
+ * retries the remote delete on the next reconcile).
+ */
+import reduxAction from "../redux/reduxAction";
+import store from "../redux/stores/rendererStore";
+import globalData from "../utils/globalData";
+import { deleteRemoteDraft, pushDeletedDraft } from "./cloudSync";
+import { addDeletedDraftId } from "./deletedDrafts";
+import { deleteData, getUserNamespacedKey } from "./store";
+
+export default async function deleteDraft(draftId: string): Promise<void> {
+  if (!draftId) return;
+
+  const storedKey = getUserNamespacedKey(`draft-${draftId}`);
+
+  await addDeletedDraftId(draftId);
+  await deleteData(`draft-${draftId}`, true);
+
+  globalData.draftsIndex = globalData.draftsIndex.filter(
+    (k) => k !== storedKey
+  );
+  reduxAction(store.dispatch, {
+    type: "REMOVE_DRAFTS_FROM_INDEX",
+    arg: [storedKey],
+  });
+
+  await pushDeletedDraft(draftId);
+  await deleteRemoteDraft(draftId);
+}

--- a/src/data/deletedDrafts.ts
+++ b/src/data/deletedDrafts.ts
@@ -1,0 +1,31 @@
+/**
+ * Tombstones for user-deleted drafts — the deletedMatches pattern, verbatim.
+ * The same three paths would otherwise re-create a deleted draft: cloud
+ * hydrate at login, syncDrafts re-pushing local rows, and a full log
+ * re-import replaying the draft.
+ */
+import { getData, putData } from "./store";
+
+const KEY = "deletedDrafts";
+
+let cache: Set<string> | null = null;
+
+/** The set of draft ids the user has deleted. Cached after the first read. */
+export async function getDeletedDraftIds(): Promise<Set<string>> {
+  if (!cache) {
+    const stored = await getData<string[]>(KEY, true);
+    cache = new Set(stored || []);
+  }
+  return cache;
+}
+
+export async function isDraftDeleted(draftId: string): Promise<boolean> {
+  return (await getDeletedDraftIds()).has(draftId);
+}
+
+export async function addDeletedDraftId(draftId: string): Promise<void> {
+  const ids = await getDeletedDraftIds();
+  if (ids.has(draftId)) return;
+  ids.add(draftId);
+  await putData<string[]>(KEY, [...ids], true);
+}

--- a/src/data/hydrateFromCloud.ts
+++ b/src/data/hydrateFromCloud.ts
@@ -33,7 +33,12 @@ import {
   materialize,
   saveLocalBackground,
 } from "./backgroundStore";
-import { fetchDeletedMatchIds, isCloudActive } from "./cloudSync";
+import {
+  fetchDeletedDraftIds,
+  fetchDeletedMatchIds,
+  isCloudActive,
+} from "./cloudSync";
+import { addDeletedDraftId, getDeletedDraftIds } from "./deletedDrafts";
 import { addDeletedMatchId, getDeletedMatchIds } from "./deletedMatches";
 import { refreshEntitlement } from "./entitlement";
 import { getData, LOCAL_KEY, putData } from "./store";
@@ -75,6 +80,7 @@ export default async function hydrateFromCloud(): Promise<void> {
     const inventoryP = supabase.from("arena_inventory").select("*");
     const ranksP = supabase.from("arena_ranks").select("*");
     const decksP = supabase.from("decks").select("*");
+    const draftsP = supabase.from("drafts").select("*");
 
     const accounts = await accountsP;
     const matches = await matchesP;
@@ -82,6 +88,7 @@ export default async function hydrateFromCloud(): Promise<void> {
     const inventory = await inventoryP;
     const ranks = await ranksP;
     const decks = await decksP;
+    const drafts = await draftsP;
 
     // Arena personas -> userids map (merged with local) + display names.
     const userids: DbUserids =
@@ -132,6 +139,27 @@ export default async function hydrateFromCloud(): Promise<void> {
         };
         await putData(key, dbMatch, true);
         if (!userids[r.arena_id]) userids[r.arena_id] = ms(r.played_at);
+      })
+    );
+
+    // Drafts — same add-only rule as matches, and the same tombstone merge:
+    // without it a fresh device would restore every draft the account has
+    // ever deleted.
+    const cloudDeletedDrafts = await fetchDeletedDraftIds();
+    const knownDeletedDrafts = await getDeletedDraftIds();
+    await Promise.all(
+      [...cloudDeletedDrafts]
+        .filter((id) => !knownDeletedDrafts.has(id))
+        .map((id) => addDeletedDraftId(id))
+    );
+    const deletedDrafts = await getDeletedDraftIds();
+
+    await Promise.all(
+      (drafts.data ?? []).map(async (r) => {
+        if (deletedDrafts.has(r.draft_id)) return;
+        const key = `draft-${r.draft_id}`;
+        if (await getData(key, true)) return;
+        await putData(key, r.internal_draft, true);
       })
     );
 

--- a/src/data/syncDrafts.ts
+++ b/src/data/syncDrafts.ts
@@ -1,0 +1,92 @@
+/**
+ * Reconcile drafts with the cloud: merge deletion tombstones both ways, drop
+ * local copies of drafts deleted elsewhere, then push what the cloud is
+ * missing. The pull direction lives in hydrateFromCloud, which restores cloud
+ * drafts on login before localLogin indexes the KV.
+ */
+import reduxAction from "../redux/reduxAction";
+import store from "../redux/stores/rendererStore";
+import { InternalDraftv2 } from "../types";
+import getLocalSetting from "../utils/getLocalSetting";
+import globalData from "../utils/globalData";
+import {
+  deleteRemoteDraft,
+  fetchDeletedDraftIds,
+  isCloudActive,
+  pushDraft,
+} from "./cloudSync";
+import { addDeletedDraftId, getDeletedDraftIds } from "./deletedDrafts";
+import { kvGet } from "./localKV";
+import { deleteData, getUserNamespacedKey, queryKeys } from "./store";
+import supabase from "./supabase";
+
+async function fetchRemoteDraftIds(): Promise<Set<string>> {
+  const { data, error } = await supabase.from("drafts").select("draft_id");
+  if (error) throw new Error(error.message);
+  return new Set((data ?? []).map((r) => r.draft_id));
+}
+
+export default async function syncDrafts(): Promise<number> {
+  if (!(await isCloudActive())) return 0;
+
+  const [remote, localKeys, cloudDeleted] = await Promise.all([
+    fetchRemoteDraftIds(),
+    queryKeys("draft-", true),
+    fetchDeletedDraftIds(),
+  ]);
+
+  // Union of what this device deleted and what any other device deleted.
+  const deleted = await getDeletedDraftIds();
+  const fresh = [...cloudDeleted].filter((id) => !deleted.has(id));
+  await Promise.all(fresh.map((id) => addDeletedDraftId(id)));
+
+  // Drop any local copy of a draft deleted elsewhere.
+  const removedKeys: string[] = [];
+  await Promise.all(
+    [...deleted].map(async (id) => {
+      const key = getUserNamespacedKey(`draft-${id}`);
+      if (!(localKeys ?? []).includes(key)) return;
+      await deleteData(`draft-${id}`, true);
+      removedKeys.push(key);
+    })
+  );
+  if (removedKeys.length) {
+    globalData.draftsIndex = globalData.draftsIndex.filter(
+      (k) => !removedKeys.includes(k)
+    );
+    reduxAction(store.dispatch, {
+      type: "REMOVE_DRAFTS_FROM_INDEX",
+      arg: removedKeys,
+    });
+  }
+
+  const localDrafts = (
+    await Promise.all(
+      (localKeys ?? [])
+        .filter((k) => !removedKeys.includes(k))
+        .map((k) => kvGet<InternalDraftv2>(k))
+    )
+  ).filter((d): d is InternalDraftv2 => !!d && !!d.id);
+
+  // Retry path for a delete made while offline: the row may still be up there.
+  await Promise.all(
+    [...deleted]
+      .filter((id) => remote.has(id))
+      .map((id) =>
+        deleteRemoteDraft(id).then((ok) => {
+          if (ok) remote.delete(id);
+        })
+      )
+  );
+
+  // Drafts recorded before the persona was known have no arenaId baked in;
+  // fall back to the current one so that backlog still syncs.
+  const currentPersona = getLocalSetting("playerId");
+  const missing = localDrafts.filter(
+    (d) => !remote.has(d.id as string) && !deleted.has(d.id as string)
+  );
+  const results = await Promise.all(
+    missing.map((d) => pushDraft(d.arenaId || currentPersona, d))
+  );
+  return results.filter(Boolean).length;
+}

--- a/src/info.json
+++ b/src/info.json
@@ -1,1 +1,1 @@
-{"version":"7.1.2","branch":"dev","timestamp":1786213446364}
+{"version":"7.1.2","branch":"restore-drafts","timestamp":1786397263081}

--- a/src/overlay/DraftOverlay.tsx
+++ b/src/overlay/DraftOverlay.tsx
@@ -1,14 +1,99 @@
+import { useEffect, useState } from "react";
+
 import CardTile, { QuantityRank } from "../components/CardTile";
+import DeckManaCurve from "../components/DeckManaCurve";
+import ManaCost from "../components/ManaCost";
 import { DRAFT_RANKS, DRAFT_RANKS_LOLA } from "../constants";
-import { DbCardDataV2, InternalDraftv2 } from "../types";
-import { DbDraftVote } from "../types/dbTypes";
+import { getData } from "../data/store";
+import { useCards } from "../hooks/useCard";
+import { Cards, DbCardDataV2, DraftRatings, InternalDraftv2 } from "../types";
+import { DbCardsData, DbDraftVote } from "../types/dbTypes";
 import getCardTypeSort from "../utils/getCardTypeSort";
+import getLocalSetting from "../utils/getLocalSetting";
 import Colors from "../utils/mtga/colors";
 import database from "../utils/mtga/database";
+import Deck from "../utils/mtga/deck";
 
 interface DraftOverlayProps {
   state: InternalDraftv2;
   votes: Record<string, DbDraftVote>;
+  /** Live 17lands numbers; when present they beat the baked-in RankData. */
+  ratings?: DraftRatings;
+  /** Color share of the picks so far, at the top of the overlay. */
+  showStats?: boolean;
+}
+
+const STAT_COLORS: { code: number; token: string; letter: string }[] = [
+  { code: 1, token: "--color-w", letter: "W" },
+  { code: 2, token: "--color-u", letter: "U" },
+  { code: 3, token: "--color-b", letter: "B" },
+  { code: 4, token: "--color-r", letter: "R" },
+  { code: 5, token: "--color-g", letter: "G" },
+];
+
+/**
+ * Share of each color among the picked cards (a multicolor card counts once
+ * per color). Rendered as a stacked bar plus per-color percentages — the
+ * at-a-glance "what am I actually drafting" readout.
+ */
+function DraftColorStats(props: { pickedCards: number[] }): JSX.Element {
+  const { pickedCards } = props;
+  const cards = useCards(pickedCards);
+
+  const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  cards.forEach((card) => {
+    if (!card?.ManaCost) return;
+    const colors = new Colors();
+    colors.addFromCost(card.ManaCost);
+    colors.get().forEach((c) => {
+      if (counts[c] !== undefined) counts[c] += 1;
+    });
+  });
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+
+  if (total === 0) return <></>;
+
+  const shares = STAT_COLORS.map((c) => ({
+    ...c,
+    pct: Math.round((counts[c.code] / total) * 100),
+  })).filter((c) => c.pct > 0);
+
+  return (
+    <div className="draft-color-stats">
+      <DeckManaCurve
+        className="draft-curve-compact"
+        deck={
+          new Deck(
+            {},
+            pickedCards.map((id) => ({ id, quantity: 1 }))
+          )
+        }
+      />
+      <div className="stats-bar">
+        {shares.map((c) => (
+          <div
+            key={`stat-seg-${c.letter}`}
+            className="seg"
+            style={{
+              width: `${(counts[c.code] / total) * 100}%`,
+              backgroundColor: `var(${c.token})`,
+            }}
+          />
+        ))}
+      </div>
+      <div className="stats-legend">
+        {shares.map((c) => (
+          // "draft-legend-mana", not "mana-16": that class is ALSO the {16}
+          // generic-cost symbol (grey circle with a 16), and its background
+          // wins the cascade over the color symbol's.
+          <div key={`stat-leg-${c.letter}`} className="entry">
+            <ManaCost className="draft-legend-mana" colors={[c.code]} />
+            {`${c.pct}%`}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function getRank(cardId: number): number | undefined {
@@ -70,7 +155,22 @@ function compareDraftPicks(
 }
 
 export default function DraftOverlay(props: DraftOverlayProps) {
-  const { state, votes } = props;
+  const { state, votes, ratings, showStats } = props;
+
+  // Card reads below are synchronous cache hits; in the overlay window the
+  // database is a proxy to the background window, so the pack has to be
+  // fetched first — this re-renders when the cards land.
+  useCards(state.packs[state.currentPack][state.currentPick] || []);
+
+  // Owned copies, straight from the shared KV — the UPSERT_DB_CARDS broadcast
+  // fires at boot, long before this window exists.
+  const [owned, setOwned] = useState<Cards | null>(null);
+  useEffect(() => {
+    const uuid = getLocalSetting("playerId") || "default";
+    getData<DbCardsData>(`${uuid}-cards`, true).then((data) => {
+      if (data?.cards) setOwned(data.cards);
+    });
+  }, []);
 
   const currentVotes: Record<number, number> = {};
   let mostVoted = -1;
@@ -91,19 +191,33 @@ export default function DraftOverlay(props: DraftOverlayProps) {
 
   return (
     <>
+      {showStats && <DraftColorStats pickedCards={state.pickedCards} />}
       {state.packs[state.currentPack][state.currentPick]
         .map((id) => database.card(id))
         .filter((a) => a)
-        .sort(compareDraftPicks)
+        .sort((a, b) => {
+          // Best win rate first when live ratings are in; otherwise the
+          // baked-in rank ordering.
+          const aR = a && ratings?.[a.GrpId];
+          const bR = b && ratings?.[b.GrpId];
+          if (aR || bR) {
+            return (bR?.gihwr ?? 0) - (aR?.gihwr ?? 0);
+          }
+          return compareDraftPicks(a, b);
+        })
         .map((fullCard) => {
           if (!fullCard) return <></>;
+          const liveRating = ratings?.[fullCard.GrpId];
           const rank = getRank(fullCard.GrpId);
+          const bakedGrade =
+            fullCard.RankData.rankSource == 0
+              ? DRAFT_RANKS[rank || 0]
+              : DRAFT_RANKS_LOLA[rank || 0];
+          const ownedCount = Math.min(4, (owned && owned[fullCard.GrpId]) || 0);
           const quantity: QuantityRank = {
             type: "RANK",
-            quantity:
-              fullCard.RankData.rankSource == 0
-                ? DRAFT_RANKS[rank || 0]
-                : DRAFT_RANKS_LOLA[rank || 0],
+            quantity: liveRating ? liveRating.grade : bakedGrade,
+            owned: owned ? ownedCount : undefined,
           };
 
           const dfcCard =

--- a/src/overlay/OverlayContent.tsx
+++ b/src/overlay/OverlayContent.tsx
@@ -4,7 +4,7 @@ import ActionLog from "../components/action-log-v2";
 import { ActionLogV2 } from "../components/action-log-v2/types";
 import OverlayDeckList from "../components/OverlayDeckList";
 import { OVERLAY_DRAFT, OVERLAY_LOG } from "../constants";
-import { InternalDraftv2 } from "../types";
+import { DraftRatings, InternalDraftv2 } from "../types";
 import Chances from "../types/chances";
 import { DbDraftVote } from "../types/dbTypes";
 import getPlayerNameWithoutSuffix from "../utils/getPlayerNameWithoutSuffix";
@@ -21,6 +21,7 @@ interface OverlayContentProps {
   actionLog?: ActionLogV2 | null;
   draftState?: InternalDraftv2;
   draftVotes?: Record<string, DbDraftVote>;
+  draftRatings?: DraftRatings;
   // The overlay window shows the QR share toggle; the public live viewer must
   // not (it can't re-share, and has no window to toggle).
   shareControls?: boolean;
@@ -45,13 +46,19 @@ export default function OverlayContent(
     actionLog,
     draftState,
     draftVotes,
+    draftRatings,
     shareControls = true,
   } = props;
 
   return (
     <>
       {settings.mode === OVERLAY_DRAFT && draftState && (
-        <DraftOverlay state={draftState} votes={draftVotes || {}} />
+        <DraftOverlay
+          state={draftState}
+          votes={draftVotes || {}}
+          ratings={draftRatings}
+          showStats={settings.draftStats !== false}
+        />
       )}
       {deck && settings.mode !== OVERLAY_LOG && (
         <OverlayDeckList

--- a/src/overlay/createOverlay.ts
+++ b/src/overlay/createOverlay.ts
@@ -31,6 +31,20 @@ export default function createOverlay(
 
   console.warn("allSettings", id, allSettings);
 
+  // Stored bounds can come from a monitor layout that no longer exists, which
+  // opens the overlay entirely off-screen — enabled, running, and invisible.
+  // Clamp the position into the nearest display's work area.
+  const { bounds } = settings;
+  const area = remote.screen.getDisplayMatching(bounds).workArea;
+  const clampedX = Math.min(
+    Math.max(bounds.x, area.x),
+    area.x + area.width - Math.min(bounds.width, 120)
+  );
+  const clampedY = Math.min(
+    Math.max(bounds.y, area.y),
+    area.y + area.height - 48
+  );
+
   const newWindow = new remote.BrowserWindow({
     transparent: allSettings.overlaysTransparency,
     // resizable: allSettings.overlayResizable,
@@ -42,8 +56,8 @@ export default function createOverlay(
     frame: allSettings.overlayFrame,
     width: settings.bounds.width,
     height: settings.bounds.height,
-    x: settings.bounds.x,
-    y: settings.bounds.y,
+    x: clampedX,
+    y: clampedY,
     alwaysOnTop: true,
     acceptFirstMouse: allSettings.overlayAcceptFirstMouse,
     webPreferences: {

--- a/src/overlay/index.tsx
+++ b/src/overlay/index.tsx
@@ -20,7 +20,7 @@ import {
   stopOverlayShare,
 } from "../data/liveShare";
 import useDebounce from "../hooks/useDebounce";
-import { InternalDraftv2 } from "../types";
+import { DraftRatings, InternalDraftv2 } from "../types";
 import Chances from "../types/chances";
 import { DbDraftVote } from "../types/dbTypes";
 import bcConnect from "../utils/bcConnect";
@@ -54,6 +54,7 @@ export default function Overlay() {
   const [matchState, setMatchState] = useState<OverlayUpdateMatchState>();
   const [draftState, setDraftState] = useState<InternalDraftv2>();
   const [draftVotes, setDraftVotes] = useState<Record<string, DbDraftVote>>({});
+  const [draftRatings, setDraftRatings] = useState<DraftRatings>();
   const [actionLog, setActionLog] = useState<ActionLogV2 | null>(null);
   const [odds, setOdds] = useState<Chances>();
   // Tracked here rather than read from redux: this is a separate renderer with
@@ -128,6 +129,10 @@ export default function Overlay() {
         setDraftState(msg.data.value);
       }
 
+      if (msg.data.type === "DRAFT_RATINGS") {
+        setDraftRatings(msg.data.value);
+      }
+
       if (msg.data.type === "ACTION_LOG") {
         setActionLog(msg.data.value);
       }
@@ -143,6 +148,11 @@ export default function Overlay() {
 
     const channel = bcConnect() as any;
     channel.onmessage = channelMessageHandler;
+
+    // This window opens BECAUSE a draft started, but it boots too late to have
+    // seen that broadcast — ask the background to repeat it. Harmless when no
+    // draft is running: the background simply does not answer.
+    postChannelMessage({ type: "DRAFT_STATUS_REQUEST" });
 
     if (remote) {
       remote.getCurrentWindow().removeAllListeners();
@@ -273,6 +283,7 @@ export default function Overlay() {
               actionLog={actionLog}
               draftState={draftState}
               draftVotes={draftVotes}
+              draftRatings={draftRatings}
             />
           )}
         </div>

--- a/src/reader/readDraftMemory.ts
+++ b/src/reader/readDraftMemory.ts
@@ -1,0 +1,46 @@
+import isElectron from "../utils/electron/isElectron";
+
+/** The payload mtga-reader's readDraft returns for an active draft. */
+export interface MemoryDraft {
+  error?: string;
+  eventName?: string;
+  draftId?: string;
+  draftState?: number;
+  currentPack?: number;
+  currentPick?: number;
+  numCardsToPick?: number;
+  packCards?: number[];
+  /**
+   * Picks in pick order, expanded by quantity. null (not []) while the draft
+   * screen is closed — the pick list lives in the draft scene and is
+   * unreadable until it reopens; position and pack stay valid.
+   */
+  pickedCards?: number[] | null;
+  sideboardCards?: number[] | null;
+  /** Human drafts only; null on bot drafts. */
+  pickSecondsTotal?: number | null;
+  passDirection?: number | null;
+}
+
+/**
+ * Read the active draft from game memory. Both draft flavours (BotDraftPod /
+ * HumanDraftPod) come back in one shape, 0-indexed. Returns null when there is
+ * no active draft, the reader is unavailable, or the read fails — callers
+ * treat memory as an optional extra source over the log, never a requirement.
+ */
+export default async function readDraftMemory(): Promise<MemoryDraft | null> {
+  if (!isElectron()) return null;
+
+  try {
+    // eslint-disable-next-line no-undef
+    const reader = __non_webpack_require__("mtga-reader");
+    if (typeof reader.readDraft !== "function") return null;
+
+    const draft: MemoryDraft = await reader.readDraft("MTGA");
+    if (!draft || draft.error) return null;
+    return draft;
+  } catch (e) {
+    console.error("readDraftMemory failed", e);
+    return null;
+  }
+}

--- a/src/reader/readDraftMemory.ts
+++ b/src/reader/readDraftMemory.ts
@@ -20,6 +20,12 @@ export interface MemoryDraft {
   /** Human drafts only; null on bot drafts. */
   pickSecondsTotal?: number | null;
   passDirection?: number | null;
+  /**
+   * "screen" when the draft screen itself held the pod (a live read);
+   * "registry" when it came from the event registry, where a finished
+   * draft's pod lingers with draftState still 2.
+   */
+  source?: "screen" | "registry";
 }
 
 /**

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -31,6 +31,7 @@ export const actions = {
   REMOVE_MATCHES_FROM_INDEX: MainDataSlice.removeMatchesFromIndex,
   SET_SEASONS: MainDataSlice.setSeasons,
   SET_DRAFTS_INDEX: MainDataSlice.setDraftsIndex,
+  REMOVE_DRAFTS_FROM_INDEX: MainDataSlice.removeDraftsFromIndex,
   SET_HIDDEN_DECKS: MainDataSlice.setHiddenDecks,
   SET_MY_USERNAME: RendererSlice.setMyUsername,
   SET_READING_LOG: RendererSlice.setReadingLog,

--- a/src/redux/slices/mainDataSlice.ts
+++ b/src/redux/slices/mainDataSlice.ts
@@ -196,6 +196,15 @@ const mainDataSlice = createSlice({
     ): void => {
       state.draftsIndex = _.uniq([...state.draftsIndex, ...action.payload]);
     },
+    // setDraftsIndex merges, so removal needs its own action — same split as
+    // the matches index.
+    removeDraftsFromIndex: (
+      state: MainState,
+      action: PayloadAction<string[]>
+    ): void => {
+      const removed = new Set(action.payload);
+      state.draftsIndex = state.draftsIndex.filter((k) => !removed.has(k));
+    },
     setHiddenDecks: (
       state: MainState,
       action: PayloadAction<string[]>
@@ -220,6 +229,7 @@ export const {
   setDecksIndex,
   setRemoteMatchesIndex,
   setLocalMatchesIndex,
+  removeDraftsFromIndex,
   removeMatchesFromIndex,
   setSeasons,
   setDraftsIndex,

--- a/src/scss/liveDraft.scss
+++ b/src/scss/liveDraft.scss
@@ -1,42 +1,312 @@
-.live-draft-container {
-  display: flex;
-  flex-direction: column;
+.drafts-list {
+  margin: 0 16px;
+  text-align: left;
+}
 
-  .title {
-    width: 100%;
-    height: 64px;
+.draft-view-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-areas:
+    "header header"
+    "pack picked";
+  gap: 16px;
+  margin-top: 16px;
+  width: 100%;
+  align-items: start;
+
+  .draft-view-header {
+    grid-area: header;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+
+    h2 {
+      margin: 0;
+    }
+
+    .draft-replay-date {
+      opacity: 0.6;
+      font-family: var(--main-font-name-it);
+      margin-left: 4px;
+    }
+
+    .draft-replay-deck-toggle {
+      margin-left: auto;
+    }
   }
 
-  .draft-container {
-    width: 100%;
+  .draft-view-pack {
+    grid-area: pack;
     display: flex;
+    flex-direction: column;
+    padding: 12px 16px 16px;
+  }
+
+  .draft-view-picked {
+    grid-area: picked;
+    display: flex;
+    flex-direction: column;
+    padding: 12px 16px 16px;
+    text-align: left;
+
+    h3 {
+      margin: 0 0 8px;
+    }
+
+    .picks-list {
+      background: var(--color-dark);
+      border-radius: 4px;
+      padding: 4px;
+    }
+  }
+
+  .draft-replay-nav {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 8px;
+
+    h3 {
+      margin: 0;
+      flex-grow: 1;
+      text-align: center;
+    }
+
+    .button-simple,
+    .button-simple-disabled {
+      width: 56px;
+      margin: 0;
+      flex-shrink: 0;
+    }
+  }
+
+  .draft-replay-scrubber {
+    position: relative;
+    width: 100%;
+    margin: 4px 0 8px;
+
+    .track {
+      position: relative;
+      height: 6px;
+      background: var(--color-section-active);
+      border-radius: 3px;
+
+      .bar {
+        height: 100%;
+        background: var(--color-status-ok);
+        border-radius: 3px;
+        transition: width 0.15s ease;
+      }
+
+      .tick {
+        position: absolute;
+        top: -4px;
+        width: 2px;
+        height: 14px;
+        transform: translateX(-50%);
+        background: rgba(255, 255, 255, 0.35);
+        border-radius: 1px;
+      }
+
+      .thumb {
+        position: absolute;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--color-status-ok);
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+        pointer-events: none;
+        transition: left 0.15s ease;
+      }
+    }
+
+    // The real control: an invisible native range over the track, so click
+    // and drag scrubbing come for free (keyboard arrows included).
+    input[type="range"] {
+      position: absolute;
+      top: -8px;
+      left: 0;
+      width: 100%;
+      height: 22px;
+      margin: 0;
+      opacity: 0;
+      cursor: pointer;
+      -webkit-appearance: none;
+    }
+
+    .labels {
+      position: relative;
+      height: 18px;
+      margin-top: 6px;
+      font-size: 12px;
+      opacity: 0.6;
+      font-family: var(--main-font-name-it);
+
+      .label {
+        position: absolute;
+        transform: translateX(-50%);
+        white-space: nowrap;
+      }
+    }
+  }
+
+  .draft-replay-deck {
+    max-width: 480px;
+    width: 100%;
+    margin: 8px auto;
+    text-align: left;
   }
 
   .pack-container {
-    width: calc(100% - 300px);
-    height: fit-content;
+    width: 100%;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    row-gap: 12px;
   }
+}
 
-  .picks-container {
-    width: 300px;
-  }
+// Color share of the picks so far, at the top of the draft overlay.
+.draft-color-stats {
+  padding: 2px 2px 6px;
 
-  .avatars-list {
+  .stats-bar {
     display: flex;
-    width: 100%;
-    height: 32px;
-    align-items: center;
-    justify-content: center;
+    height: 8px;
+    overflow: hidden;
+    background: var(--color-section-active);
 
-    .vote-avatar {
-      width: 24px;
-      height: 24px;
-      border-radius: 64px;
-      box-shadow: rgba(0, 0, 0, 0.3) 0px 3px 7px 0px;
-      background-size: contain;
+    .seg {
+      height: 100%;
+      transition: width 0.25s ease;
     }
+  }
+
+  .stats-legend {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--color-text);
+    font-family: var(--main-font-name);
+
+    .entry {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+    }
+
+    // Flat (unshadowed) mana symbol sized for the legend. Deliberately NOT
+    // mana-16 — that class doubles as the {16} generic-cost symbol.
+    .draft-legend-mana {
+      pointer-events: none;
+      background-size: contain;
+      background-repeat: no-repeat;
+      width: 14px;
+      height: 14px;
+    }
+  }
+}
+
+// The deck view's mana curve, shrunk to the draft overlay's form factor.
+.mana-curve-container.draft-curve-compact {
+  margin: 2px auto 8px;
+  padding: 0 2px;
+  width: 100%;
+
+  .mana-curve {
+    height: 64px;
+  }
+
+  .mana-curve-value {
+    font-size: 10px;
+    line-height: 12px;
+    margin-bottom: 2px;
+  }
+
+  .mana-curve-bar {
+    max-width: 14px;
+    border-radius: 0;
+    gap: 1px;
+  }
+
+  .mana-curve-tick {
+    font-size: 10px;
+    line-height: 14px;
+    bottom: -16px;
+  }
+
+  // Must clear the ticks hanging below the curve box (bottom: -16px above).
+  .mana-curve-summary {
+    font-size: 10px;
+    margin-top: 22px;
+  }
+}
+
+// A sibling of the CardTile in the row's flex container must not push it past
+// the overlay's edge — the tile shrinks (its base style insists on width:100%).
+.draft-card-tile-container {
+  .card-tile-container-outer {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+  }
+}
+
+// Owned-copy pips, rendered INSIDE the rank cell so they share the tile's
+// hover state. Absolute at the cell's left edge; the rank letter stays
+// centered on its own.
+.card-tile-odds-flat.with-owned-pips {
+  position: relative;
+  // Breathing room between the pip column and the centered rank letter.
+  padding-left: 4px;
+}
+
+.draft-owned-pips {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-right: 2px;
+  pointer-events: none;
+
+  .pip {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--color-section-active);
+  }
+
+  .pip.owned {
+    background: var(--color-button);
+  }
+}
+
+.draft-pick-selected {
+  position: relative;
+  outline: 3px solid var(--color-status-ok);
+  border-radius: 6px;
+  box-shadow: 0 0 16px rgba(95, 191, 133, 0.45);
+
+  .draft-pick-selected-badge {
+    position: absolute;
+    bottom: -2px;
+    left: 50%;
+    transform: translate(-50%, 50%);
+    background: var(--color-status-ok);
+    color: var(--color-dark);
+    font-family: var(--main-font-name-bold);
+    font-size: 11px;
+    letter-spacing: 1px;
+    padding: 1px 8px;
+    border-radius: 8px;
+    pointer-events: none;
   }
 }

--- a/src/scss/liveDraft.scss
+++ b/src/scss/liveDraft.scss
@@ -3,6 +3,20 @@
   text-align: left;
 }
 
+// Aggregate winrate over the drafts the filters left visible.
+.drafts-stats-bar {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin: 8px 16px 12px;
+  color: var(--color-text-dark);
+
+  span {
+    color: var(--color-text);
+    font-weight: 500;
+  }
+}
+
 .draft-view-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -1,4 +1,4 @@
-import { InternalDeck } from "./deck";
+import { InternalDeck, v2cardsList } from "./deck";
 import { ModuleInstanceData } from "./event";
 
 export interface DraftStatus {
@@ -40,6 +40,10 @@ export interface InternalDraftv2 {
   packs: [number[][], number[][], number[][]];
   picks: [number[], number[], number[]];
   type: "draft";
+  // The deck submitted for the event once the draft ended, when we saw it.
+  deckId?: string;
+  deckMain?: v2cardsList;
+  deckSide?: v2cardsList;
 }
 
 export interface InternalDraftPackPick {
@@ -74,6 +78,18 @@ export interface InternalDraft {
   CurrentModule?: string;
   PreviousOpponents?: string[];
 }
+
+/** One card's 17lands rating for the set being drafted. */
+export interface DraftRating {
+  /** Letter grade derived from the win rate's z-score within the set. */
+  grade: string;
+  /** "Games in hand" win rate, 0..1 — the headline 17lands number. */
+  gihwr: number;
+  /** Average last seen at — how late the card wheels. */
+  alsa: number;
+}
+
+export type DraftRatings = Record<number, DraftRating>;
 
 export interface DraftNotify {
   draftId: string;

--- a/src/utils/getSetInEventId.ts
+++ b/src/utils/getSetInEventId.ts
@@ -7,10 +7,13 @@ export default function getSetInEventId(
     return undefined;
   }
 
+  // An empty arenacode (indexOf("") is 0) would "match" every event id and,
+  // coming earlier in table order, shadow the real set.
   const setCodes = Object.keys(database.sets)
-    .filter(
-      (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
-    )
+    .filter((setName) => {
+      const code = database.sets[setName].arenacode;
+      return code !== "" && eventId.indexOf(code) !== -1;
+    })
     .map((setName) => database.sets[setName].arenacode);
 
   return setCodes[0] || undefined;

--- a/src/utils/seventeenLands.ts
+++ b/src/utils/seventeenLands.ts
@@ -1,0 +1,137 @@
+import postChannelMessage from "../broadcastChannel/postChannelMessage";
+import { DraftRatings } from "../types/draft";
+import isElectron from "./electron/isElectron";
+import getSetInEventId from "./getSetInEventId";
+
+// One fetch per set+queue per session; every draft in the same queue reuses it.
+const cache: Record<string, DraftRatings | null> = {};
+const pending: Record<string, boolean> = {};
+
+function eventTypeFor(eventId: string): string {
+  if (eventId.indexOf("QuickDraft") !== -1) return "QuickDraft";
+  if (eventId.indexOf("TradDraft") !== -1) return "TradDraft";
+  return "PremierDraft";
+}
+
+/** GIH WR z-scores bucketed the way 17lands presents grades. */
+function gradeFor(z: number): string {
+  if (z >= 2.0) return "A+";
+  if (z >= 1.67) return "A";
+  if (z >= 1.33) return "A-";
+  if (z >= 1.0) return "B+";
+  if (z >= 0.67) return "B";
+  if (z >= 0.33) return "B-";
+  if (z >= 0) return "C+";
+  if (z >= -0.33) return "C";
+  if (z >= -0.67) return "C-";
+  if (z >= -1.0) return "D+";
+  if (z >= -1.33) return "D";
+  if (z >= -1.67) return "D-";
+  return "F";
+}
+
+// Field names are 17lands' own.
+/* eslint-disable camelcase */
+interface SeventeenLandsCard {
+  mtga_id: number;
+  ever_drawn_win_rate: number | null;
+  avg_seen: number | null;
+}
+/* eslint-enable camelcase */
+
+function httpsGetJson(url: string): Promise<any> {
+  // The renderer can't fetch() this — 17lands sends no CORS headers — but with
+  // nodeIntegration Node's https is CORS-free.
+  // eslint-disable-next-line no-undef
+  const https = __non_webpack_require__("https");
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res: any) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`17lands responded ${res.statusCode}`));
+          return;
+        }
+        let body = "";
+        res.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+function toRatings(cards: SeventeenLandsCard[]): DraftRatings {
+  const rated = cards.filter(
+    (c) => c.mtga_id && typeof c.ever_drawn_win_rate === "number"
+  );
+  const rates = rated.map((c) => c.ever_drawn_win_rate as number);
+  const mean = rates.reduce((a, b) => a + b, 0) / (rates.length || 1);
+  const std =
+    Math.sqrt(
+      rates.reduce((a, b) => a + (b - mean) * (b - mean), 0) /
+        (rates.length || 1)
+    ) || 1;
+
+  const ratings: DraftRatings = {};
+  rated.forEach((c) => {
+    const gihwr = c.ever_drawn_win_rate as number;
+    ratings[c.mtga_id] = {
+      grade: gradeFor((gihwr - mean) / std),
+      gihwr,
+      alsa: c.avg_seen ?? 0,
+    };
+  });
+  return ratings;
+}
+
+function postRatings(ratings: DraftRatings): void {
+  postChannelMessage({ type: "DRAFT_RATINGS", value: ratings });
+}
+
+/**
+ * Fetch ratings for the event's set and broadcast them to the overlay. Safe to
+ * call on every draft status update — after the first call per queue it only
+ * re-broadcasts the cached result (so an overlay that opened late still gets
+ * them).
+ */
+export default function loadDraftRatings(eventId: string): void {
+  if (!isElectron()) return;
+
+  const set = getSetInEventId(eventId);
+  if (!set) return;
+
+  const eventType = eventTypeFor(eventId);
+  const key = `${set}-${eventType}`;
+
+  const cached = cache[key];
+  if (cached) {
+    postRatings(cached);
+    return;
+  }
+  if (pending[key]) return;
+  pending[key] = true;
+
+  const url = `https://www.17lands.com/api/card_data?expansion=${set}&event_type=${eventType}&time_period=ALL_TIME`;
+  httpsGetJson(url)
+    .then((json) => {
+      const cards: SeventeenLandsCard[] = json?.data ?? [];
+      const ratings = toRatings(cards);
+      cache[key] = ratings;
+      pending[key] = false;
+      if (Object.keys(ratings).length > 0) {
+        postRatings(ratings);
+      }
+    })
+    .catch((e) => {
+      pending[key] = false;
+      console.warn("17lands ratings fetch failed", e);
+    });
+}

--- a/supabase/migrations/20260810115813_drafts.sql
+++ b/supabase/migrations/20260810115813_drafts.sql
@@ -1,0 +1,35 @@
+-- Cloud storage for drafts, mirroring the matches pattern: one row per draft
+-- keyed (user_id, draft_id), the full record as jsonb beside a few queryable
+-- columns. draft_id is Arena's CourseId, which is what the local records key
+-- on too (draft-<id> in the KV), so the two sides reconcile by id alone.
+--
+-- No tombstone table yet: the app has no way to delete a draft. If one is
+-- added, copy deleted_matches — the resurrection loop it prevents applies
+-- identically here.
+create table if not exists public.drafts (
+  user_id uuid not null default auth.uid(),
+  draft_id text not null,
+  arena_id text not null,
+  event_id text,
+  draft_set text,
+  played_at timestamptz,
+  deck_id text,
+  internal_draft jsonb not null,
+  created_at timestamptz not null default now(),
+  primary key (user_id, draft_id),
+  constraint drafts_user_id_arena_id_fkey
+    foreign key (user_id, arena_id)
+    references public.arena_accounts (user_id, arena_id)
+    on delete cascade
+);
+
+alter table public.drafts enable row level security;
+
+-- Same shape as matches_owner: your own rows, all operations.
+drop policy if exists drafts_owner on public.drafts;
+create policy drafts_owner
+  on public.drafts
+  for all
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);

--- a/supabase/migrations/20260810140657_deleted_drafts.sql
+++ b/supabase/migrations/20260810140657_deleted_drafts.sql
@@ -1,0 +1,21 @@
+-- Cloud tombstones for deleted drafts — the deleted_matches pattern, verbatim.
+-- Without this a draft deleted on one device is re-pushed by any other device
+-- that still holds it locally (syncDrafts) and restored on fresh logins
+-- (hydrateFromCloud). The tombstone is the shared fact both paths consult.
+create table if not exists public.deleted_drafts (
+  user_id uuid not null references auth.users (id) on delete cascade,
+  draft_id text not null,
+  deleted_at timestamptz not null default now(),
+  primary key (user_id, draft_id)
+);
+
+alter table public.deleted_drafts enable row level security;
+
+-- Same shape as deleted_matches_owner: your own rows, all operations.
+drop policy if exists deleted_drafts_owner on public.deleted_drafts;
+create policy deleted_drafts_owner
+  on public.deleted_drafts
+  for all
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10473,10 +10473,10 @@ ms@2.1.1:
   version "2.1.1"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-mtga-reader@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.9.tgz"
-  integrity sha512-zNEOEMRuuGy/WU9/y9GaIKVVvqxa7nGSfteuPL/N9i94XITamLMWKMhnGpDn+tERrNk2fHhTmB03rLjbgqZTiw==
+mtga-reader@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.npmjs.org/mtga-reader/-/mtga-reader-0.1.10.tgz"
+  integrity sha512-W/NRrgKTSRC3hSdZPWn/GWqmN+pyfKIt6GJh6qscLgh/2MfbmsT3IfCSyIf7XXENtHBVBfs3gzyv6tYnIZCjRQ==
 
 mtgatool-shared@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Drafts had been silently dead since the 2026 client dropped the `Namespace_Method` separators from its log labels — the handlers existed but nothing dispatched to them. This restores the whole feature for bot drafts (Quick Draft) and builds out what was always missing, validated against a live draft and a full replay simulation of its captured log.

## Parsing (2026 format)
- Dual-spelling label cases for `BotDraftDraftStatus` / `BotDraftDraftPick`, a new `EventJoin` case (its response now nests the course, and is where the record id comes from), and `EventGetCoursesV2` routed to the real courses handler instead of an empty stub.
- Picks send `CardIds` (array) now; the final pick's `Completed` response repeats the last coordinates with an **empty** `DraftPack` — it no longer erases the recorded one-card pack, and doubles as the `DRAFT_END` signal (the `Draft→DeckBuilder` scene line's spaced JSON `"context":"deck builder"` never survives the decoder's bare-label pattern, documented rather than touched).
- `getSetInEventId` matched every event against the one set with an empty arenacode (`indexOf("") === 0`), returning `undefined` for everything — this had also killed `draftSet` and 17lands set resolution.
- Mid-draft app restarts re-attach: pick responses rebuild draft identity, the server's `PickedCards` list repairs missed picks, and the record id is re-adopted from the courses refresh at the latest.

## Records & cloud
- The submitted decklist is stored on the draft record at `EventSetDeckV3` time via a new `DRAFT_SAVE` message (persists without flipping `draftInProgress`).
- Drafts sync like matches: `drafts` table + `deleted_drafts` tombstones (migrations included, already applied), push on save, login reconcile, hydrate restore, cross-device delete without resurrection.

## UI
- **Drafts tab**: list of recorded drafts (deck colors, age, delete with confirm dialog) → `/drafts/:id` replay: pack/pick navigation with a scrubber and pack-boundary ticks, the chosen card highlighted with a PICK badge, the accumulating pool, and the final decklist.
- **Draft overlay** now actually opens (three fixes: overlays only re-evaluated on `matchInProgress`; stored bounds from stale monitor layouts opened windows off-screen — now clamped; `DraftOverlay` read cards synchronously against the proxied DB so every tile was `undefined` and autosize collapsed the window). Overlays request state on mount, so the first pick isn't a blank window.
- Overlay content: pack sorted by live **17lands** ratings with letter grades (z-score buckets over GIH WR, fetched per set+queue via Node https — renderer fetch is CORS-blocked), owned-copy pips inside the rank cell, and an on-by-default draft stats block (compact reuse of the deck view's mana curve + color share bar + per-color percentages with flat mana symbols).

## Tests
`draftParsing.spec.ts` replays a fully synthetic 2026-format draft through watcher → decoder → switch: join, picks, the empty `Completed` response regression, deck submit, courses refresh, and `DRAFT_END` emission. 20 suites / 72 tests green; tsc and eslint clean.

Premier/Traditional (human) drafts are a follow-up — different label family, likely needing the memory reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)