### PR TITLE
Public deck sharing

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -38,6 +38,7 @@ import Admin from "./popups/Admin";
 import ArenaIdSelector from "./popups/ArenaIdSelector";
 import DetailedLogs from "./popups/DetailedLogs";
 import SettingsPersistor from "./SettingsPersistor";
+import SharedDeckView from "./SharedDeckView";
 import TopBar from "./TopBar";
 import TopNav from "./TopNav";
 import ViewSettings from "./views/settings/ViewSettings";
@@ -88,9 +89,13 @@ function App(props: AppProps) {
   }, [matchInProgress, draftInProgress]);
 
   useEffect(() => {
-    // The public live-share viewer (/live/<token>) must work with no account —
-    // never bounce it to /auth or run the login flow for it.
-    if (history.location.pathname.startsWith("/live/")) return;
+    // The public pages (/live/<token>, /share/deck/<token>) must work with no
+    // account — never bounce them to /auth or run the login flow for them.
+    if (
+      history.location.pathname.startsWith("/live/") ||
+      history.location.pathname.startsWith("/share/")
+    )
+      return;
     if (canLogin) {
       const autoLogin = getLocalSetting("autoLogin");
 
@@ -192,14 +197,18 @@ function App(props: AppProps) {
   // Show the "What's new" modal once per version, on app open — before login,
   // so returning users see the new-account / no-carryover notice up front.
   useEffect(() => {
-    // Not over the live-share viewer. That view is pointed at by the deck QR
-    // code and captured as an OBS browser source, where a modal nobody can
-    // reach sits on the stream until the scene is rebuilt.
+    // Not over the public pages. The live viewer is captured as an OBS
+    // browser source, where a modal nobody can reach sits on the stream until
+    // the scene is rebuilt; a shared-deck visitor may have no account at all.
     //
     // Returning before the flag is written, not after opening: marking the
-    // version seen here would spend the notice on a window the streamer is
+    // version seen here would spend the notice on a window the person is
     // not looking at, and they would never be shown it in the app itself.
-    if (history.location.pathname.startsWith("/live/")) return;
+    if (
+      history.location.pathname.startsWith("/live/") ||
+      history.location.pathname.startsWith("/share/")
+    )
+      return;
     if (getLocalSetting("whatsNewSeen") !== info.version) {
       openWhatsNew.current();
       setLocalSetting("whatsNewSeen", info.version);
@@ -317,6 +326,8 @@ function App(props: AppProps) {
             <Route exact path="/auth" component={Auth} />
             {/* Public (no login): live overlay share viewer, see LiveShareView */}
             <Route exact path="/live/:id" component={LiveShareView} />
+            {/* Public (no login): shared deck page, see SharedDeckView */}
+            <Route exact path="/share/deck/:id" component={SharedDeckView} />
             <Route path="/:page">
               <>
                 <TopNav

--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -14,7 +14,7 @@ import {
 } from "../redux/slices/FilterSlice";
 import { AppState } from "../redux/stores/rendererStore";
 import { CardsData } from "../types/collectionTypes";
-import { defaultCardsData } from "../types/dbTypes";
+import { defaultCardsData, StatsDeck } from "../types/dbTypes";
 import aggregateStats from "../utils/aggregateStats";
 import cardsDb from "../utils/cardsDb/cardsDbClient";
 import isElectron from "../utils/electron/isElectron";
@@ -31,6 +31,7 @@ import ConfirmDialog from "./popups/ConfirmDialog";
 import DeckViewPopup from "./popups/DeckViewPopup";
 import AdvancedSearch from "./views/collection/advancedSearch";
 import ViewCollection from "./views/collection/ViewCollection";
+import ShareDeckPopup from "./views/decks/ShareDeckPopup";
 import ViewDecks from "./views/decks/ViewDecks";
 import ViewDrafts from "./views/drafts/ViewDrafts";
 import ViewExplore from "./views/explore/ViewExplore";
@@ -210,6 +211,18 @@ const ContentWrapper = (mainProps: ContentWrapperProps) => {
     if (matchToDelete) deleteMatch(matchToDelete.matchId);
   }, [matchToDelete]);
 
+  // Deck sharing confirm. Same reason it lives up here: PopupComponent
+  // positions against the nearest positioned ancestor, so rendering it down
+  // in the deck view pinned it to the bottom of the page.
+  const openShareDeck = useRef<() => void>(vodiFn);
+  const closeShareDeck = useRef<() => void>(vodiFn);
+  const [deckToShare, setDeckToShare] = useState<StatsDeck | null>(null);
+
+  const askShareDeck = useCallback((deck: StatsDeck) => {
+    setDeckToShare(deck);
+    openShareDeck.current();
+  }, []);
+
   const CurrentPage = Object.values(views)[viewIndex];
 
   const datePickerCallbackRef = useRef((_d: Date) => {
@@ -314,6 +327,12 @@ const ContentWrapper = (mainProps: ContentWrapperProps) => {
         />
       </PopupComponent>
 
+      <ShareDeckPopup
+        deck={deckToShare}
+        openFnRef={openShareDeck}
+        closeFnRef={closeShareDeck}
+      />
+
       <div className="wrapper">
         <div className="wrapper-inner">
           <div className="overflow-ux">
@@ -343,6 +362,7 @@ const ContentWrapper = (mainProps: ContentWrapperProps) => {
                       datePickerDoShow={datePickerDoShow}
                       matchesData={matchesData}
                       deleteMatchCallback={askDeleteMatch}
+                      shareDeckCallback={askShareDeck}
                     />
                   </animated.div>
                 );
@@ -367,6 +387,7 @@ const ContentWrapper = (mainProps: ContentWrapperProps) => {
                   datePickerDoShow={datePickerDoShow}
                   matchesData={matchesData}
                   deleteMatchCallback={askDeleteMatch}
+                  shareDeckCallback={askShareDeck}
                 />
               </div>
             )}

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import logoBig from "../assets/images/logo_big.png";
+import { DEFAULT_AVATAR, DEFAULT_TILE } from "../constants";
+import { fetchSharedDeck, SharedDeckPayload } from "../data/sharedDecks";
+import { useCardArtCrop } from "../hooks/useCardImage";
+import cardsDb from "../utils/cardsDb/cardsDbClient";
+import compareCards from "../utils/compareCards";
+import copyToClipboard from "../utils/copyToClipboard";
+import Colors from "../utils/mtga/colors";
+import Deck from "../utils/mtga/deck";
+import openExternal from "../utils/openExternal";
+import DeckColorsBar from "./DeckColorsBar";
+import DeckColorStats from "./DeckColorStats";
+import DeckList from "./DeckList";
+import DeckManaCurve from "./DeckManaCurve";
+import DeckRarities from "./DeckRarities";
+import DeckSampleHand from "./DeckSampleHand";
+import DeckTypesStats from "./DeckTypesStats";
+import ManaCost from "./ManaCost";
+import Separator from "./Separator";
+import SupporterBadge from "./SupporterBadge";
+import Button from "./ui/Button";
+import Section from "./ui/Section";
+
+/**
+ * Public shared-deck page (app.mtgatool.com/share/deck/<token>) — what a
+ * "make public" link resolves to. Same layout as the in-app deck view minus
+ * anything personal to a viewer or owner: no deck changes, no card winrates,
+ * no crafting cost. Deliberately unauthenticated, like /live/:id — the token
+ * is an unguessable capability and this route mounts outside the login gate.
+ */
+export default function SharedDeckView(): JSX.Element {
+  const params = useParams<{ id: string }>();
+  const [dbReady, setDbReady] = useState(false);
+  const [payload, setPayload] = useState<SharedDeckPayload | null>(null);
+  const [missing, setMissing] = useState(false);
+
+  // Card names/art need the cards database; load it without any login.
+  useEffect(() => {
+    cardsDb
+      .init()
+      .then(() => setDbReady(true))
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    fetchSharedDeck(params.id).then((data) => {
+      if (data) setPayload(data);
+      else setMissing(true);
+    });
+  }, [params.id]);
+
+  const snapshot = payload?.deck;
+  const deck = useMemo(() => {
+    const d = new Deck(
+      {
+        commandZoneGRPIds: snapshot?.commanders?.map((c) => c.id),
+        companionGRPId: snapshot?.companions?.map((c) => c.id)[0],
+      },
+      snapshot?.mainDeck || [],
+      snapshot?.sideboard || []
+    );
+    d.setName(snapshot?.name || "Deck");
+    d.tile = snapshot?.deckTileId || DEFAULT_TILE;
+    return d;
+  }, [snapshot]);
+
+  const deckArt = useCardArtCrop(snapshot?.deckTileId || DEFAULT_TILE);
+
+  const arenaExport = (): void => {
+    deck.sortMainboard(compareCards);
+    deck.sortSideboard(compareCards);
+    copyToClipboard(deck.getExportArena());
+  };
+
+  if (missing) {
+    return (
+      <div className="shared-deck-missing">
+        <img src={logoBig} alt="MTG Arena Tool" />
+        <div>This deck is no longer shared.</div>
+        <div
+          className="shared-deck-cta"
+          onClick={() => openExternal("https://mtgatool.com")}
+        >
+          mtgatool.com
+        </div>
+      </div>
+    );
+  }
+
+  if (!payload || !dbReady || !snapshot) {
+    return <div className="shared-deck-missing">Loading deck…</div>;
+  }
+
+  const { owner } = payload;
+  const ownerName = owner?.username || "A Planeswalker";
+  const wr = payload.winrate;
+  const games = wr ? wr.wins + wr.losses : 0;
+
+  return (
+    <div className="shared-deck-page">
+      <div className="decks-top" style={{ backgroundImage: `url(${deckArt})` }}>
+        <DeckColorsBar deck={deck} />
+        <div className="top-inner">
+          <div className="flex-item">
+            <div
+              className="shared-deck-avatar"
+              style={{
+                backgroundImage: `url(${owner?.avatar_url || DEFAULT_AVATAR})`,
+              }}
+            />
+            <div className="shared-deck-title">
+              <div className="shared-deck-name">{snapshot.name}</div>
+              <div className="shared-deck-owner">
+                by {ownerName}
+                {owner && owner.supporter_tier > 0 ? (
+                  <SupporterBadge tier={owner.supporter_tier} />
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <div className="flex-item">
+            {wr && games > 0 ? (
+              <div
+                className="shared-deck-record"
+                title={`${wr.wins} wins, ${wr.losses} losses`}
+              >
+                <span className="record">{`${wr.wins}-${wr.losses}`}</span>
+                <span
+                  className="percent"
+                  style={{
+                    color:
+                      wr.wins / games >= 0.5
+                        ? "var(--color-g)"
+                        : "var(--color-r)",
+                  }}
+                >
+                  {`${((wr.wins / games) * 100).toFixed(0)}%`}
+                </span>
+              </div>
+            ) : null}
+            <ManaCost
+              className="mana-s20"
+              colors={new Colors().addFromBits(snapshot.colors || 0).get()}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="regular-view-grid">
+        <Section
+          style={{ justifyContent: "space-between", gridArea: "controls" }}
+        >
+          <Button
+            style={{ margin: "16px" }}
+            className="button-simple"
+            text="Export to Arena"
+            onClick={arenaExport}
+          />
+        </Section>
+        <Section
+          style={{
+            flexDirection: "column",
+            gridArea: "deck",
+            paddingBottom: "16px",
+            paddingLeft: "24px",
+          }}
+        >
+          <DeckList deck={deck} showWildcards={false} />
+        </Section>
+        <Section style={{ flexDirection: "column", gridArea: "types" }}>
+          <Separator>Types</Separator>
+          <DeckTypesStats deck={deck} />
+        </Section>
+        <Section style={{ flexDirection: "column", gridArea: "curves" }}>
+          <Separator>Mana Curve</Separator>
+          <DeckManaCurve deck={deck} />
+        </Section>
+        <Section style={{ flexDirection: "column", gridArea: "pies" }}>
+          <Separator>Colors</Separator>
+          <DeckColorStats deck={deck} />
+        </Section>
+        <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
+          <Separator>Cards by rarity</Separator>
+          <DeckRarities deck={deck} />
+        </Section>
+        <Section style={{ flexDirection: "column", gridArea: "hand" }}>
+          <Separator>Sample hand</Separator>
+          <DeckSampleHand deck={deck} />
+        </Section>
+      </div>
+
+      <div
+        className="shared-deck-footer"
+        onClick={() => openExternal("https://mtgatool.com")}
+      >
+        Tracked with <b>MTG Arena Tool</b> — free deck tracker for MTG Arena
+      </div>
+    </div>
+  );
+}

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import logoBig from "../assets/images/logo_big.png";
 import { DEFAULT_AVATAR, DEFAULT_TILE } from "../constants";
 import { fetchSharedDeck, SharedDeckPayload } from "../data/sharedDecks";
+import { useCards } from "../hooks/useCard";
 import { useCardArtCrop } from "../hooks/useCardImage";
 import cardsDb from "../utils/cardsDb/cardsDbClient";
 import compareCards from "../utils/compareCards";
@@ -34,25 +35,50 @@ import Section from "./ui/Section";
 export default function SharedDeckView(): JSX.Element {
   const params = useParams<{ id: string }>();
   const [dbReady, setDbReady] = useState(false);
+  const [dbFailed, setDbFailed] = useState(false);
   const [payload, setPayload] = useState<SharedDeckPayload | null>(null);
   const [missing, setMissing] = useState(false);
 
-  // Card names/art need the cards database; load it without any login.
+  // Card names/art need the cards database; load it without any login. A
+  // failure must surface — otherwise the page sits on "Loading" forever.
   useEffect(() => {
     cardsDb
       .init()
-      .then(() => setDbReady(true))
-      .catch(() => undefined);
+      .then((ready) => (ready ? setDbReady(true) : setDbFailed(true)))
+      .catch(() => setDbFailed(true));
   }, []);
 
   useEffect(() => {
+    // Reset for the new token, and ignore a slow answer for the previous one.
+    setPayload(null);
+    setMissing(false);
+    let cancelled = false;
     fetchSharedDeck(params.id).then((data) => {
+      if (cancelled) return;
       if (data) setPayload(data);
       else setMissing(true);
     });
+    return () => {
+      cancelled = true;
+    };
   }, [params.id]);
 
   const snapshot = payload?.deck;
+
+  // The curve/types/colors charts read cards synchronously from the lookup
+  // cache, which is empty on a cold public page — they rendered blank until
+  // something else happened to fetch the cards. Prefetch every id and rebuild
+  // the deck once they land (same fix as the Home top decks).
+  const allIds = useMemo(() => {
+    const ids = new Set<number>();
+    (snapshot?.mainDeck || []).forEach((c) => ids.add(c.id));
+    (snapshot?.sideboard || []).forEach((c) => ids.add(c.id));
+    (snapshot?.commanders || []).forEach((c) => ids.add(c.id));
+    (snapshot?.companions || []).forEach((c) => ids.add(c.id));
+    return [...ids];
+  }, [snapshot]);
+  const resolvedCards = useCards(allIds);
+
   const deck = useMemo(() => {
     const d = new Deck(
       {
@@ -65,14 +91,24 @@ export default function SharedDeckView(): JSX.Element {
     d.setName(snapshot?.name || "Deck");
     d.tile = snapshot?.deckTileId || DEFAULT_TILE;
     return d;
-  }, [snapshot]);
+    // resolvedCards is the point: the charts below read from the card cache,
+    // which is only warm once these lookups come back.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshot, resolvedCards]);
 
   const deckArt = useCardArtCrop(snapshot?.deckTileId || DEFAULT_TILE);
 
   const arenaExport = (): void => {
-    deck.sortMainboard(compareCards);
-    deck.sortSideboard(compareCards);
-    copyToClipboard(deck.getExportArena());
+    // A fresh Deck: sorting in place would reorder the memoized one the page
+    // is rendering.
+    const exportDeck = new Deck(
+      {},
+      snapshot?.mainDeck || [],
+      snapshot?.sideboard || []
+    );
+    exportDeck.sortMainboard(compareCards);
+    exportDeck.sortSideboard(compareCards);
+    copyToClipboard(exportDeck.getExportArena());
   };
 
   if (missing) {
@@ -86,6 +122,15 @@ export default function SharedDeckView(): JSX.Element {
         >
           mtgatool.com
         </div>
+      </div>
+    );
+  }
+
+  if (dbFailed) {
+    return (
+      <div className="shared-deck-missing">
+        <img src={logoBig} alt="MTG Arena Tool" />
+        <div>Could not load the card database — try reloading the page.</div>
       </div>
     );
   }

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -101,27 +101,45 @@ export default function SharedDeckView(): JSX.Element {
 
   return (
     <div className="shared-deck-page">
-      <div className="decks-top" style={{ backgroundImage: `url(${deckArt})` }}>
-        <DeckColorsBar deck={deck} />
-        <div className="top-inner">
-          <div className="flex-item">
-            <div
-              className="shared-deck-avatar"
-              style={{
-                backgroundImage: `url(${owner?.avatar_url || DEFAULT_AVATAR})`,
-              }}
-            />
-            <div className="shared-deck-title">
-              <div className="shared-deck-name">{snapshot.name}</div>
-              <div className="shared-deck-owner">
-                by {ownerName}
-                {owner && owner.supporter_tier > 0 ? (
-                  <SupporterBadge tier={owner.supporter_tier} />
-                ) : null}
+      <div className="shared-deck-content">
+        <div
+          className="decks-top"
+          style={{ backgroundImage: `url(${deckArt})` }}
+        >
+          <DeckColorsBar deck={deck} />
+          <div className="top-inner">
+            <div className="flex-item">
+              <div
+                className="shared-deck-avatar"
+                style={{
+                  backgroundImage: `url(${
+                    owner?.avatar_url || DEFAULT_AVATAR
+                  })`,
+                }}
+              />
+              <div className="shared-deck-title">
+                <div className="shared-deck-name">{snapshot.name}</div>
+                <div className="shared-deck-owner">
+                  by {ownerName}
+                  {owner && owner.supporter_tier > 0 ? (
+                    <SupporterBadge tier={owner.supporter_tier} />
+                  ) : null}
+                </div>
               </div>
             </div>
+            <div className="flex-item">
+              <ManaCost
+                className="mana-s20"
+                colors={new Colors().addFromBits(snapshot.colors || 0).get()}
+              />
+            </div>
           </div>
-          <div className="flex-item">
+        </div>
+
+        <div className="regular-view-grid">
+          <Section
+            style={{ justifyContent: "space-between", gridArea: "controls" }}
+          >
             {wr && games > 0 ? (
               <div
                 className="shared-deck-record"
@@ -139,64 +157,56 @@ export default function SharedDeckView(): JSX.Element {
                 >
                   {`${((wr.wins / games) * 100).toFixed(0)}%`}
                 </span>
+                <span className="record-label">win rate</span>
               </div>
-            ) : null}
-            <ManaCost
-              className="mana-s20"
-              colors={new Colors().addFromBits(snapshot.colors || 0).get()}
+            ) : (
+              <div />
+            )}
+            <Button
+              style={{ margin: "16px" }}
+              className="button-simple"
+              text="Export to Arena"
+              onClick={arenaExport}
             />
-          </div>
+          </Section>
+          <Section
+            style={{
+              flexDirection: "column",
+              gridArea: "deck",
+              paddingBottom: "16px",
+              paddingLeft: "24px",
+            }}
+          >
+            <DeckList deck={deck} showWildcards={false} />
+          </Section>
+          <Section style={{ flexDirection: "column", gridArea: "types" }}>
+            <Separator>Types</Separator>
+            <DeckTypesStats deck={deck} />
+          </Section>
+          <Section style={{ flexDirection: "column", gridArea: "curves" }}>
+            <Separator>Mana Curve</Separator>
+            <DeckManaCurve deck={deck} />
+          </Section>
+          <Section style={{ flexDirection: "column", gridArea: "pies" }}>
+            <Separator>Colors</Separator>
+            <DeckColorStats deck={deck} />
+          </Section>
+          <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
+            <Separator>Cards by rarity</Separator>
+            <DeckRarities deck={deck} />
+          </Section>
+          <Section style={{ flexDirection: "column", gridArea: "hand" }}>
+            <Separator>Sample hand</Separator>
+            <DeckSampleHand deck={deck} />
+          </Section>
         </div>
-      </div>
 
-      <div className="regular-view-grid">
-        <Section
-          style={{ justifyContent: "space-between", gridArea: "controls" }}
+        <div
+          className="shared-deck-footer"
+          onClick={() => openExternal("https://mtgatool.com")}
         >
-          <Button
-            style={{ margin: "16px" }}
-            className="button-simple"
-            text="Export to Arena"
-            onClick={arenaExport}
-          />
-        </Section>
-        <Section
-          style={{
-            flexDirection: "column",
-            gridArea: "deck",
-            paddingBottom: "16px",
-            paddingLeft: "24px",
-          }}
-        >
-          <DeckList deck={deck} showWildcards={false} />
-        </Section>
-        <Section style={{ flexDirection: "column", gridArea: "types" }}>
-          <Separator>Types</Separator>
-          <DeckTypesStats deck={deck} />
-        </Section>
-        <Section style={{ flexDirection: "column", gridArea: "curves" }}>
-          <Separator>Mana Curve</Separator>
-          <DeckManaCurve deck={deck} />
-        </Section>
-        <Section style={{ flexDirection: "column", gridArea: "pies" }}>
-          <Separator>Colors</Separator>
-          <DeckColorStats deck={deck} />
-        </Section>
-        <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
-          <Separator>Cards by rarity</Separator>
-          <DeckRarities deck={deck} />
-        </Section>
-        <Section style={{ flexDirection: "column", gridArea: "hand" }}>
-          <Separator>Sample hand</Separator>
-          <DeckSampleHand deck={deck} />
-        </Section>
-      </div>
-
-      <div
-        className="shared-deck-footer"
-        onClick={() => openExternal("https://mtgatool.com")}
-      >
-        Tracked with <b>MTG Arena Tool</b> — free deck tracker for MTG Arena
+          Tracked with <b>MTG Arena Tool</b> — free deck tracker for MTG Arena
+        </div>
       </div>
     </div>
   );

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -24,6 +24,7 @@ import Separator from "./Separator";
 import SupporterBadge from "./SupporterBadge";
 import Button from "./ui/Button";
 import Section from "./ui/Section";
+import VisualDeckView from "./views/decks/VisualDeckView";
 
 /**
  * Public shared-deck page (app.mtgatool.com/share/deck/<token>) — what a
@@ -38,6 +39,7 @@ export default function SharedDeckView(): JSX.Element {
   const [dbFailed, setDbFailed] = useState(false);
   const [payload, setPayload] = useState<SharedDeckPayload | null>(null);
   const [missing, setMissing] = useState(false);
+  const [visual, setVisual] = useState(false);
 
   // Card names/art need the cards database; load it without any login. A
   // failure must surface — otherwise the page sits on "Loading" forever.
@@ -181,70 +183,82 @@ export default function SharedDeckView(): JSX.Element {
           </div>
         </div>
 
-        <div className="regular-view-grid">
-          <Section
-            style={{ justifyContent: "space-between", gridArea: "controls" }}
-          >
-            {wr && games > 0 ? (
-              <div
-                className="shared-deck-record"
-                title={`${wr.wins} wins, ${wr.losses} losses`}
-              >
-                <span className="record">{`${wr.wins}-${wr.losses}`}</span>
-                <span
-                  className="percent"
-                  style={{
-                    color:
-                      wr.wins / games >= 0.5
-                        ? "var(--color-g)"
-                        : "var(--color-r)",
-                  }}
+        {visual ? (
+          <VisualDeckView deck={deck} setRegularView={() => setVisual(false)} />
+        ) : (
+          <div className="regular-view-grid">
+            <Section
+              style={{ justifyContent: "space-between", gridArea: "controls" }}
+            >
+              {wr && games > 0 ? (
+                <div
+                  className="shared-deck-record"
+                  title={`${wr.wins} wins, ${wr.losses} losses`}
                 >
-                  {`${((wr.wins / games) * 100).toFixed(0)}%`}
-                </span>
-                <span className="record-label">win rate</span>
+                  <span className="record">{`${wr.wins}-${wr.losses}`}</span>
+                  <span
+                    className="percent"
+                    style={{
+                      color:
+                        wr.wins / games >= 0.5
+                          ? "var(--color-g)"
+                          : "var(--color-r)",
+                    }}
+                  >
+                    {`${((wr.wins / games) * 100).toFixed(0)}%`}
+                  </span>
+                  <span className="record-label">win rate</span>
+                </div>
+              ) : (
+                <div />
+              )}
+              <div style={{ display: "flex" }}>
+                <Button
+                  style={{ margin: "16px" }}
+                  className="button-simple"
+                  text="Visual View"
+                  onClick={() => setVisual(true)}
+                />
+                <Button
+                  style={{ margin: "16px" }}
+                  className="button-simple"
+                  text="Export to Arena"
+                  onClick={arenaExport}
+                />
               </div>
-            ) : (
-              <div />
-            )}
-            <Button
-              style={{ margin: "16px" }}
-              className="button-simple"
-              text="Export to Arena"
-              onClick={arenaExport}
-            />
-          </Section>
-          <Section
-            style={{
-              flexDirection: "column",
-              gridArea: "deck",
-              paddingBottom: "16px",
-              paddingLeft: "24px",
-            }}
-          >
-            <DeckList deck={deck} showWildcards={false} />
-          </Section>
-          <Section style={{ flexDirection: "column", gridArea: "types" }}>
-            <Separator>Types</Separator>
-            <DeckTypesStats deck={deck} />
-          </Section>
-          <Section style={{ flexDirection: "column", gridArea: "curves" }}>
-            <Separator>Mana Curve</Separator>
-            <DeckManaCurve deck={deck} />
-          </Section>
-          <Section style={{ flexDirection: "column", gridArea: "pies" }}>
-            <Separator>Colors</Separator>
-            <DeckColorStats deck={deck} />
-          </Section>
-          <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
-            <Separator>Cards by rarity</Separator>
-            <DeckRarities deck={deck} />
-          </Section>
-          <Section style={{ flexDirection: "column", gridArea: "hand" }}>
-            <Separator>Sample hand</Separator>
-            <DeckSampleHand deck={deck} />
-          </Section>
-        </div>
+            </Section>
+            <Section
+              style={{
+                flexDirection: "column",
+                gridArea: "deck",
+                paddingBottom: "16px",
+                paddingLeft: "24px",
+              }}
+            >
+              <DeckList deck={deck} showWildcards={false} />
+            </Section>
+            <Section style={{ flexDirection: "column", gridArea: "types" }}>
+              <Separator>Types</Separator>
+              <DeckTypesStats deck={deck} />
+            </Section>
+            <Section style={{ flexDirection: "column", gridArea: "curves" }}>
+              <Separator>Mana Curve</Separator>
+              <DeckManaCurve deck={deck} />
+            </Section>
+            <Section style={{ flexDirection: "column", gridArea: "pies" }}>
+              <Separator>Colors</Separator>
+              <DeckColorStats deck={deck} />
+            </Section>
+            <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
+              <Separator>Cards by rarity</Separator>
+              <DeckRarities deck={deck} />
+            </Section>
+            <Section style={{ flexDirection: "column", gridArea: "hand" }}>
+              <Separator>Sample hand</Separator>
+              <DeckSampleHand deck={deck} />
+            </Section>
+          </div>
+        )}
 
         <div
           className="shared-deck-footer"

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -23,6 +23,10 @@ interface WhatsNewItem {
  */
 const NEW_IN_THIS_VERSION: WhatsNewItem[] = [
   {
+    title: "Share your decks",
+    body: "Decks have a Share button now: it copies a public link anyone can open — no account needed — showing the decklist, mana curve, types, colors and sample hands, plus your win rate with the deck if you choose to show it (and your Patreon badge, supporters). Stop sharing any time and the link dies.",
+  },
+  {
     title: "Top ranked players",
     body: "The Home tab shows the top 10 ranked players on Constructed and Limited, with their avatars and current rank.",
   },

--- a/src/components/views/decks/DeckView.tsx
+++ b/src/components/views/decks/DeckView.tsx
@@ -45,10 +45,13 @@ const VIEW_WINRATES = 3;
 
 interface DeckViewProps {
   openDeckView: (deck: Deck) => void;
+  /** Opens the share popup, which lives up in ContentWrapper — rendering it
+   * here would trap it inside this view's positioned container. */
+  shareDeckCallback?: (deck: StatsDeck) => void;
 }
 
 export default function DeckView(props: DeckViewProps): JSX.Element {
-  const { openDeckView } = props;
+  const { openDeckView, shareDeckCallback } = props;
 
   const dispatch = useDispatch();
   const history = useHistory();
@@ -241,6 +244,14 @@ export default function DeckView(props: DeckViewProps): JSX.Element {
                 text="Export to Arena"
                 onClick={arenaExport}
               />
+              {shareDeckCallback && (
+                <Button
+                  style={{ margin: "16px" }}
+                  className="button-simple"
+                  text="Share"
+                  onClick={() => dbDeck && shareDeckCallback(dbDeck)}
+                />
+              )}
             </Section>
             <Section
               style={{

--- a/src/components/views/decks/ShareDeckPopup.tsx
+++ b/src/components/views/decks/ShareDeckPopup.tsx
@@ -103,11 +103,21 @@ export default function ShareDeckPopup(props: ShareDeckPopupProps) {
           list is a snapshot: share again after editing to refresh it.
         </p>
         {shareId ? (
-          <input
-            readOnly
-            value={sharedDeckUrl(shareId)}
-            onFocus={(e) => e.target.select()}
-          />
+          <div className="share-deck-link-row">
+            <input
+              readOnly
+              value={sharedDeckUrl(shareId)}
+              onFocus={(e) => e.target.select()}
+            />
+            <div
+              className="copy-button"
+              title="Copy link"
+              onClick={() => {
+                copyToClipboard(sharedDeckUrl(shareId));
+                toast("Public link copied to clipboard.");
+              }}
+            />
+          </div>
         ) : null}
         <Checkbox
           text="Show my win rate with this deck"

--- a/src/components/views/decks/ShareDeckPopup.tsx
+++ b/src/components/views/decks/ShareDeckPopup.tsx
@@ -40,12 +40,21 @@ export default function ShareDeckPopup(props: ShareDeckPopupProps) {
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    if (!deck?.id) return;
+    if (!deck?.id) return undefined;
+    // Fully reset for the new deck — nothing of the previous share (link or
+    // checkbox) may leak into it — and drop a stale answer if the deck
+    // changes mid-fetch.
     setShareId(null);
+    setIncludeWinrate(true);
+    let cancelled = false;
     getMyDeckShare(deck.id).then((existing) => {
-      setShareId(existing?.shareId ?? null);
-      if (existing) setIncludeWinrate(existing.includeWinrate);
+      if (cancelled || !existing) return;
+      setShareId(existing.shareId);
+      setIncludeWinrate(existing.includeWinrate);
     });
+    return () => {
+      cancelled = true;
+    };
   }, [deck?.id]);
 
   const toast = useCallback(

--- a/src/components/views/decks/ShareDeckPopup.tsx
+++ b/src/components/views/decks/ShareDeckPopup.tsx
@@ -1,0 +1,135 @@
+import { MutableRefObject, useCallback, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import {
+  getMyDeckShare,
+  sharedDeckUrl,
+  shareDeck,
+  stopSharingDeck,
+} from "../../../data/sharedDecks";
+import reduxAction from "../../../redux/reduxAction";
+import { StatsDeck } from "../../../types/dbTypes";
+import copyToClipboard from "../../../utils/copyToClipboard";
+import isElectron from "../../../utils/electron/isElectron";
+import getPopupClass from "../../../utils/getPopupClass";
+import PopupComponent from "../../PopupComponent";
+import Button from "../../ui/Button";
+import Checkbox from "../../ui/Checkbox";
+
+interface ShareDeckPopupProps {
+  /** Null until a deck asks to be shared; the popup stays mounted either
+   * way so its open/close refs are always wired. */
+  deck: StatsDeck | null;
+  openFnRef: MutableRefObject<() => void>;
+  closeFnRef: MutableRefObject<() => void>;
+}
+
+/**
+ * The "make public" dialog. Sharing upserts a snapshot of the deck under a
+ * stable capability token and puts the public URL on the clipboard; anyone
+ * with the link can view the deck without an account. Stop sharing deletes
+ * the row and the link dies with it.
+ */
+export default function ShareDeckPopup(props: ShareDeckPopupProps) {
+  const { deck, openFnRef, closeFnRef } = props;
+  const dispatch = useDispatch();
+  const os = isElectron() ? process.platform : "";
+
+  const [shareId, setShareId] = useState<string | null>(null);
+  const [includeWinrate, setIncludeWinrate] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!deck?.id) return;
+    setShareId(null);
+    getMyDeckShare(deck.id).then((existing) => {
+      setShareId(existing?.shareId ?? null);
+      if (existing) setIncludeWinrate(existing.includeWinrate);
+    });
+  }, [deck?.id]);
+
+  const toast = useCallback(
+    (text: string) => {
+      reduxAction(dispatch, {
+        type: "SET_POPUP",
+        arg: { text, duration: 5000, time: new Date().getTime() },
+      });
+    },
+    [dispatch]
+  );
+
+  const doShare = useCallback(() => {
+    if (busy || !deck) return;
+    setBusy(true);
+    shareDeck(deck, includeWinrate).then((share) => {
+      setBusy(false);
+      if (!share) {
+        toast("Could not share the deck — are you signed in?");
+        return;
+      }
+      setShareId(share.shareId);
+      copyToClipboard(sharedDeckUrl(share.shareId));
+      toast("Public link copied to clipboard.");
+    });
+  }, [busy, deck, includeWinrate, toast]);
+
+  const doStop = useCallback(() => {
+    const deckId = deck?.id;
+    if (busy || !deckId) return;
+    setBusy(true);
+    stopSharingDeck(deckId).then((ok) => {
+      setBusy(false);
+      if (ok) {
+        setShareId(null);
+        toast("The deck is no longer public.");
+      }
+    });
+  }, [busy, deck, toast]);
+
+  return (
+    <PopupComponent
+      open={false}
+      className={getPopupClass(os)}
+      width="520px"
+      height="auto"
+      openFnRef={openFnRef}
+      closeFnRef={closeFnRef}
+      persistent={false}
+    >
+      <div className="share-deck-popup">
+        <div className="share-deck-title">Share this deck</div>
+        <p>
+          Anyone with the link can view the decklist — no account needed. The
+          list is a snapshot: share again after editing to refresh it.
+        </p>
+        {shareId ? (
+          <input
+            readOnly
+            value={sharedDeckUrl(shareId)}
+            onFocus={(e) => e.target.select()}
+          />
+        ) : null}
+        <Checkbox
+          text="Show my win rate with this deck"
+          value={includeWinrate}
+          callback={setIncludeWinrate}
+        />
+        <div className="share-deck-buttons">
+          <Button
+            text={shareId ? "Update & copy link" : "Share & copy link"}
+            onClick={doShare}
+            disabled={busy}
+          />
+          {shareId ? (
+            <Button
+              text="Stop sharing"
+              className="button-simple-dark"
+              onClick={doStop}
+              disabled={busy}
+            />
+          ) : null}
+        </div>
+      </div>
+    </PopupComponent>
+  );
+}

--- a/src/components/views/decks/ViewDecks.tsx
+++ b/src/components/views/decks/ViewDecks.tsx
@@ -4,6 +4,7 @@ import { Route, Switch, useRouteMatch } from "react-router-dom";
 
 import useIsLoggedIn from "../../../hooks/useIsLoggedIn";
 import { AppState } from "../../../redux/stores/rendererStore";
+import { StatsDeck } from "../../../types/dbTypes";
 import Deck from "../../../utils/mtga/deck";
 import SegmentedToggle from "../../ui/SegmentedToggle";
 import DecksList from "./DecksList";
@@ -13,6 +14,7 @@ interface ViewDecksProps {
   openHistoryStatsPopup: () => void;
   datePickerDoShow: () => void;
   openDeckView: (deck: Deck) => void;
+  shareDeckCallback?: (deck: StatsDeck) => void;
 }
 
 type DecksTab = "played" | "saved";
@@ -43,7 +45,12 @@ export default function ViewDecks(props: ViewDecksProps) {
   const { url } = useRouteMatch();
   const loggedIn = useIsLoggedIn();
 
-  const { openHistoryStatsPopup, datePickerDoShow, openDeckView } = props;
+  const {
+    openHistoryStatsPopup,
+    datePickerDoShow,
+    openDeckView,
+    shareDeckCallback,
+  } = props;
 
   const decksIndex = useSelector(
     (state: AppState) => state.mainData.decksIndex
@@ -56,7 +63,10 @@ export default function ViewDecks(props: ViewDecksProps) {
   return (
     <Switch>
       <Route exact path={`${url}/:id`}>
-        <DeckView openDeckView={openDeckView} />
+        <DeckView
+          openDeckView={openDeckView}
+          shareDeckCallback={shareDeckCallback}
+        />
       </Route>
       <Route exact path={`${url}/`}>
         {/* One DecksList for both tabs: the filter chrome (and the toggle

--- a/src/data/database.types.ts
+++ b/src/data/database.types.ts
@@ -378,6 +378,36 @@ export type Database = {
           }
         ];
       };
+      shared_decks: {
+        Row: {
+          created_at: string;
+          deck: Json;
+          deck_id: string;
+          include_winrate: boolean;
+          share_id: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          deck: Json;
+          deck_id: string;
+          include_winrate?: boolean;
+          share_id: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Update: {
+          created_at?: string;
+          deck?: Json;
+          deck_id?: string;
+          include_winrate?: boolean;
+          share_id?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       profiles: {
         Row: {
           avatar_url: string | null;
@@ -422,6 +452,10 @@ export type Database = {
           limited: Json | null;
           updated_at: string;
         }[];
+      };
+      get_shared_deck: {
+        Args: { p_share_id: string };
+        Returns: Json;
       };
       get_public_profiles: {
         Args: { p_arena_ids: string[] };

--- a/src/data/database.types.ts
+++ b/src/data/database.types.ts
@@ -415,6 +415,7 @@ export type Database = {
           created_at: string;
           id: string;
           is_private: boolean;
+          supporter_tier: number;
           updated_at: string;
           username: string | null;
         };
@@ -424,6 +425,7 @@ export type Database = {
           created_at?: string;
           id: string;
           is_private?: boolean;
+          supporter_tier?: number;
           updated_at?: string;
           username?: string | null;
         };
@@ -433,6 +435,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           is_private?: boolean;
+          supporter_tier?: number;
           updated_at?: string;
           username?: string | null;
         };

--- a/src/data/sharedDecks.ts
+++ b/src/data/sharedDecks.ts
@@ -1,0 +1,156 @@
+/**
+ * Public deck sharing. A share is a row in `shared_decks`: an unguessable
+ * token mapping to a SNAPSHOT of the decklist (played decks only exist in
+ * local stats, so there is nothing server-side to link to — re-sharing
+ * refreshes the snapshot) plus a live winrate flag. Anonymous viewers read
+ * through the `get_shared_deck` RPC, which exposes only public fields and
+ * respects the owner's private-mode profile.
+ */
+import { StatsDeck } from "../types/dbTypes";
+import { v2cardsList } from "../types/deck";
+import sha1 from "../utils/sha1";
+import textRandom from "../utils/textRandom";
+import { getActiveUserId } from "./cloudSync";
+import { Json } from "./database.types";
+import supabase from "./supabase";
+
+/** The decklist snapshot stored in (and served from) a share row. */
+export interface SharedDeckSnapshot {
+  name: string;
+  deckTileId: number;
+  colors: number;
+  mainDeck: v2cardsList;
+  sideboard: v2cardsList;
+  commanders?: v2cardsList;
+  companions?: v2cardsList;
+}
+
+// Field names come from the RPC's jsonb, hence the database spelling.
+/* eslint-disable camelcase */
+export interface SharedDeckOwner {
+  username: string | null;
+  avatar_url: string | null;
+  supporter_tier: number;
+}
+
+export interface SharedDeckPayload {
+  deck: SharedDeckSnapshot;
+  updated_at: string;
+  owner: SharedDeckOwner | null;
+  winrate: { wins: number; losses: number } | null;
+}
+/* eslint-enable camelcase */
+
+function snapshotOf(deck: StatsDeck): SharedDeckSnapshot {
+  return {
+    name: deck.name,
+    deckTileId: deck.deckTileId,
+    colors: deck.colors,
+    mainDeck: deck.mainDeck,
+    sideboard: deck.sideboard,
+    commanders: deck.commanders,
+    companions: deck.companions,
+  };
+}
+
+export interface MyDeckShare {
+  shareId: string;
+  includeWinrate: boolean;
+}
+
+/** The signed-in user's existing share for a deck, if any. */
+export async function getMyDeckShare(
+  deckId: string
+): Promise<MyDeckShare | null> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId) return null;
+    const { data, error } = await supabase
+      .from("shared_decks")
+      .select("*")
+      .eq("deck_id", deckId)
+      .maybeSingle();
+    if (error || !data) return null;
+    return { shareId: data.share_id, includeWinrate: data.include_winrate };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create (or refresh) the public share for a deck. Keeps an existing link
+ * stable: re-sharing updates the snapshot and settings under the same token.
+ */
+export async function shareDeck(
+  deck: StatsDeck,
+  includeWinrate: boolean
+): Promise<MyDeckShare | null> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId || !deck.id) return null;
+
+    const existing = await getMyDeckShare(deck.id);
+    const shareId =
+      existing?.shareId || sha1(`${textRandom(64)}-${new Date().getTime()}`);
+
+    const { error } = await supabase.from("shared_decks").upsert(
+      {
+        share_id: shareId,
+        user_id: userId,
+        deck_id: deck.id,
+        deck: snapshotOf(deck) as unknown as Json,
+        include_winrate: includeWinrate,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id,deck_id" }
+    );
+    if (error) {
+      console.error("[sharedDecks] shareDeck:", error.message);
+      return null;
+    }
+    return { shareId, includeWinrate };
+  } catch (e) {
+    console.error("[sharedDecks] shareDeck threw:", e);
+    return null;
+  }
+}
+
+/** Delete the share; the link stops working immediately. */
+export async function stopSharingDeck(deckId: string): Promise<boolean> {
+  try {
+    const userId = await getActiveUserId();
+    if (!userId) return false;
+    const { error } = await supabase
+      .from("shared_decks")
+      .delete()
+      .eq("user_id", userId)
+      .eq("deck_id", deckId);
+    if (error) {
+      console.error("[sharedDecks] stopSharingDeck:", error.message);
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve a share token — public, works without a session. */
+export async function fetchSharedDeck(
+  shareId: string
+): Promise<SharedDeckPayload | null> {
+  try {
+    const { data, error } = await supabase.rpc("get_shared_deck", {
+      p_share_id: shareId,
+    });
+    if (error || !data) return null;
+    return data as unknown as SharedDeckPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** The public URL a share token resolves to. */
+export function sharedDeckUrl(shareId: string): string {
+  return `https://app.mtgatool.com/share/deck/${shareId}`;
+}

--- a/src/data/sharedDecks.ts
+++ b/src/data/sharedDecks.ts
@@ -8,8 +8,6 @@
  */
 import { StatsDeck } from "../types/dbTypes";
 import { v2cardsList } from "../types/deck";
-import sha1 from "../utils/sha1";
-import textRandom from "../utils/textRandom";
 import { getActiveUserId } from "./cloudSync";
 import { Json } from "./database.types";
 import supabase from "./supabase";
@@ -40,6 +38,15 @@ export interface SharedDeckPayload {
   winrate: { wins: number; losses: number } | null;
 }
 /* eslint-enable camelcase */
+
+/** 160 bits from the platform CSPRNG, hex — an unguessable capability. */
+function newShareToken(): string {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 function snapshotOf(deck: StatsDeck): SharedDeckSnapshot {
   return {
@@ -89,26 +96,37 @@ export async function shareDeck(
     const userId = await getActiveUserId();
     if (!userId || !deck.id) return null;
 
-    const existing = await getMyDeckShare(deck.id);
-    const shareId =
-      existing?.shareId || sha1(`${textRandom(64)}-${new Date().getTime()}`);
-
-    const { error } = await supabase.from("shared_decks").upsert(
+    // Insert-then-update rather than a blind upsert: an upsert on
+    // (user_id, deck_id) would overwrite share_id — the primary key the
+    // public link is made of — killing an existing link on every re-share
+    // (and in any race). The insert only wins when no share exists; the
+    // update refreshes content without ever touching the token.
+    await supabase.from("shared_decks").upsert(
       {
-        share_id: shareId,
+        share_id: newShareToken(),
         user_id: userId,
         deck_id: deck.id,
         deck: snapshotOf(deck) as unknown as Json,
         include_winrate: includeWinrate,
-        updated_at: new Date().toISOString(),
       },
-      { onConflict: "user_id,deck_id" }
+      { onConflict: "user_id,deck_id", ignoreDuplicates: true }
     );
+    const { error } = await supabase
+      .from("shared_decks")
+      .update({
+        deck: snapshotOf(deck) as unknown as Json,
+        include_winrate: includeWinrate,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+      .eq("deck_id", deck.id);
     if (error) {
       console.error("[sharedDecks] shareDeck:", error.message);
       return null;
     }
-    return { shareId, includeWinrate };
+    const share = await getMyDeckShare(deck.id);
+    if (!share) return null;
+    return { shareId: share.shareId, includeWinrate };
   } catch (e) {
     console.error("[sharedDecks] shareDeck threw:", e);
     return null;

--- a/src/scss/decksView.scss
+++ b/src/scss/decksView.scss
@@ -135,3 +135,129 @@
   grid-template-rows: auto auto;
   grid-template-areas: "controls controls" "deck changes";
 }
+
+// ------------------------------------------------------------- deck sharing
+.share-deck-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  color: var(--color-text);
+
+  .share-deck-title {
+    font-size: 18px;
+    font-family: var(--main-font-name-it);
+  }
+
+  p {
+    margin: 0;
+    color: var(--color-text-dark);
+    font-size: 14px;
+  }
+
+  input {
+    background-color: var(--color-base);
+    border: 1px solid var(--color-dark);
+    border-radius: 3px;
+    color: var(--color-text);
+    padding: 6px 10px;
+    font-size: 13px;
+    width: 100%;
+  }
+
+  .share-deck-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 4px;
+  }
+}
+
+// The public /share/deck/<token> page. Reuses the deck view grid; only the
+// header identity strip and footer are its own.
+.shared-deck-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-bottom: 24px;
+
+  .shared-deck-avatar {
+    width: 40px;
+    height: 40px;
+    min-width: 40px;
+    border-radius: 40px;
+    background-size: cover;
+    background-position: center;
+    margin: auto 12px auto 8px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  }
+
+  .shared-deck-title {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-shadow: 3px 3px 6px #000000;
+
+    .shared-deck-name {
+      color: var(--color-text-hover);
+      font-size: 20px;
+      line-height: 24px;
+    }
+
+    .shared-deck-owner {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--color-text);
+      font-size: 13px;
+      font-family: var(--main-font-name-it);
+    }
+  }
+
+  .shared-deck-record {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-right: 16px;
+    text-shadow: 3px 3px 6px #000000;
+
+    .record {
+      font-size: 22px;
+      color: var(--color-text-hover);
+    }
+
+    .percent {
+      font-size: 16px;
+    }
+  }
+
+  .shared-deck-footer {
+    text-align: center;
+    margin-top: 24px;
+    padding: 12px;
+    color: var(--color-text-dark);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--color-text);
+    }
+  }
+}
+
+.shared-deck-missing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding-top: 15vh;
+  color: var(--color-text);
+
+  img {
+    width: 160px;
+    opacity: 0.9;
+  }
+
+  .shared-deck-cta {
+    color: var(--color-text-link);
+    cursor: pointer;
+  }
+}

--- a/src/scss/decksView.scss
+++ b/src/scss/decksView.scss
@@ -165,6 +165,16 @@
     width: 100%;
   }
 
+  .share-deck-link-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    input {
+      flex: 1 1 auto;
+    }
+  }
+
   .share-deck-buttons {
     display: flex;
     justify-content: center;
@@ -175,10 +185,53 @@
 
 // The public /share/deck/<token> page. Reuses the deck view grid; only the
 // header identity strip and footer are its own.
+//
+// Its own scroll container, positioned above the wrapper: the app body has
+// overflow hidden (in-app views scroll inside ContentWrapper, which this
+// page does not have), and .app-wrapper-back's ::after overlay both covers
+// unpositioned content and eats its pointer events — cards were unhoverable
+// until this stacked above it.
 .shared-deck-page {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding-bottom: 24px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  .shared-deck-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding-bottom: 24px;
+  }
+
+  // Same trick as the post-match MVP banner: a dark gradient rising from the
+  // bottom so the name and owner stay readable over any card art.
+  .decks-top {
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        to top,
+        rgba(10, 10, 11, 0.9) 0%,
+        rgba(10, 10, 11, 0.55) 55%,
+        rgba(10, 10, 11, 0.15) 100%
+      );
+      pointer-events: none;
+    }
+
+    > * {
+      position: relative;
+    }
+  }
 
   .shared-deck-avatar {
     width: 40px;
@@ -217,16 +270,20 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
-    margin-right: 16px;
-    text-shadow: 3px 3px 6px #000000;
+    margin: auto 16px;
 
     .record {
       font-size: 22px;
-      color: var(--color-text-hover);
+      color: var(--color-text);
     }
 
     .percent {
       font-size: 16px;
+    }
+
+    .record-label {
+      font-size: 12px;
+      color: var(--color-text-dark);
     }
   }
 

--- a/src/scss/decksView.scss
+++ b/src/scss/decksView.scss
@@ -204,7 +204,7 @@
   .shared-deck-content {
     max-width: 1200px;
     margin: 0 auto;
-    padding-bottom: 24px;
+    padding: 0 16px 24px;
   }
 
   // Same trick as the post-match MVP banner: a dark gradient rising from the

--- a/supabase/migrations/20260811233831_shared_decks.sql
+++ b/supabase/migrations/20260811233831_shared_decks.sql
@@ -1,0 +1,83 @@
+-- Public deck sharing. A row is one deck the owner chose to publish: the
+-- share_id is an unguessable capability token (same model as live_overlays),
+-- and the row carries a SNAPSHOT of the decklist — played decks only exist in
+-- the client's local stats, so there is nothing server-side to point at.
+-- Re-sharing the same deck refreshes the snapshot. The winrate, by contrast,
+-- is computed live from the owner's matches at view time.
+
+create table public.shared_decks (
+  share_id text primary key,
+  user_id uuid not null default auth.uid(),
+  -- Arena deck GUID, for the live winrate join against matches.
+  deck_id text not null,
+  -- Displayable snapshot: name, tile, colors, mainDeck, sideboard,
+  -- commanders, companions.
+  deck jsonb not null,
+  include_winrate boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  -- One share per deck; sharing again updates it in place, keeping the link.
+  unique (user_id, deck_id)
+);
+
+alter table public.shared_decks enable row level security;
+
+-- Owners manage their own shares. There is deliberately NO public select on
+-- the table: anonymous viewers go through the RPC below, which exposes only
+-- public fields.
+create policy "owners manage their shares"
+  on public.shared_decks
+  for all
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- Everything the public share page needs, in one call, for anyone holding
+-- the token: the deck snapshot, the owner's public identity (hidden when
+-- their profile is private — the deck stays visible, the identity does not),
+-- their supporter tier for the Patreon badge, and the deck's live record
+-- when the owner opted in.
+create or replace function public.get_shared_deck(p_share_id text)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select jsonb_build_object(
+    'deck', sd.deck,
+    'updated_at', sd.updated_at,
+    'owner', case
+      when coalesce(p.is_private, false) then jsonb_build_object(
+        'username', null,
+        'avatar_url', null,
+        'supporter_tier', coalesce(p.supporter_tier, 0)
+      )
+      else jsonb_build_object(
+        'username', p.username,
+        'avatar_url', p.avatar_url,
+        'supporter_tier', coalesce(p.supporter_tier, 0)
+      )
+    end,
+    'winrate', case
+      when sd.include_winrate then (
+        select jsonb_build_object(
+          'wins', count(*) filter (
+            where coalesce(m.player_wins, 0) > coalesce(m.player_losses, 0)
+          ),
+          'losses', count(*) filter (
+            where coalesce(m.player_wins, 0) <= coalesce(m.player_losses, 0)
+          )
+        )
+        from matches m
+        where m.user_id = sd.user_id and m.player_deck_id = sd.deck_id
+      )
+      else null
+    end
+  )
+  from shared_decks sd
+  left join profiles p on p.id = sd.user_id
+  where sd.share_id = p_share_id;
+$$;
+
+grant execute on function public.get_shared_deck(text) to anon, authenticated;


### PR DESCRIPTION
Decks get a **Share** button that publishes them at a public URL anyone can open — no account needed.

## How it works

- **Share popup** (on the deck view, played and saved decks alike): a "Show my win rate" checkbox, **Share & copy link**, and **Stop sharing**. Sharing upserts a *snapshot* of the decklist into a new `shared_decks` table under an unguessable capability token (same model as `live_overlays`) and puts `app.mtgatool.com/share/deck/<token>` on the clipboard. Re-sharing updates the snapshot under the same link; stop sharing deletes the row and the link dies.
- **Public page** (`/share/deck/:id`, mounted outside the login gate like `/live/:id`): decklist, types, mana curve, colors, rarities and sample hand — the same components as the in-app view. Deliberately excluded: deck changes, card winrates, and crafting cost (viewer-dependent). Header shows the deck art, the owner's avatar/username, their **Patreon supporter badge** (`profiles.supporter_tier`, the public mirror), and the deck's **W–L + winrate** when enabled. Footer links back to mtgatool.com. Private-mode profiles show as "A Planeswalker" with no avatar — the deck stays visible, the identity doesn't.
- **Winrate is live**, computed by the RPC from the owner's matches at view time (`player_deck_id` join) — the snapshot is only the list, so the record keeps updating for bragging rights.

## Data

`supabase/migrations/20260811233831_shared_decks.sql` (**already applied to production**): `shared_decks` with owner-only RLS and *no* public table read — anonymous viewers go through the `get_shared_deck` security-definer RPC, which exposes only public fields. One share per deck (`unique (user_id, deck_id)`), so links stay stable across updates.

## Notes

- The share popup mounts up in ContentWrapper with the other popups — PopupComponent positions against the nearest positioned ancestor, and mounting it inside the deck view pinned it to the bottom of the page (caught in review of the first build).
- Verified end-to-end on the web build: share created, link resolves anonymously with the record badge (35-19, 65%), stop-sharing kills it.
- Groundwork for "featured decklists" on Home later: `explore_decks` + public shares compose naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Share decks through public links with optional win-rate visibility.
  * View shared decks without signing in, including deck details, owner information, statistics, sample hands, visualizations, and Arena export.
  * Manage sharing, copy links, refresh access, or revoke links from the sharing dialog.
  * Shared pages include loading and unavailable-deck states.
  * Public shared-deck links open directly without authentication.
* **Documentation**
  * Added a “What’s New” entry introducing deck sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->