### PR TITLE
Public player profiles

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -41,6 +41,7 @@ import SettingsPersistor from "./SettingsPersistor";
 import SharedDeckView from "./SharedDeckView";
 import TopBar from "./TopBar";
 import TopNav from "./TopNav";
+import PublicProfilePage from "./views/profile/PublicProfilePage";
 import ViewSettings from "./views/settings/ViewSettings";
 import WhatsNewPopup from "./WhatsNewPopup";
 
@@ -89,11 +90,13 @@ function App(props: AppProps) {
   }, [matchInProgress, draftInProgress]);
 
   useEffect(() => {
-    // The public pages (/live/<token>, /share/deck/<token>) must work with no
-    // account — never bounce them to /auth or run the login flow for them.
+    // The public pages (/live/<token>, /share/deck/<token>, /profile/<id>)
+    // must work with no account — never bounce them to /auth or run the
+    // login flow for them.
     if (
       history.location.pathname.startsWith("/live/") ||
-      history.location.pathname.startsWith("/share/")
+      history.location.pathname.startsWith("/share/") ||
+      history.location.pathname.startsWith("/profile/")
     )
       return;
     if (canLogin) {
@@ -206,7 +209,8 @@ function App(props: AppProps) {
     // not looking at, and they would never be shown it in the app itself.
     if (
       history.location.pathname.startsWith("/live/") ||
-      history.location.pathname.startsWith("/share/")
+      history.location.pathname.startsWith("/share/") ||
+      history.location.pathname.startsWith("/profile/")
     )
       return;
     if (getLocalSetting("whatsNewSeen") !== info.version) {
@@ -328,6 +332,22 @@ function App(props: AppProps) {
             <Route exact path="/live/:id" component={LiveShareView} />
             {/* Public (no login): shared deck page, see SharedDeckView */}
             <Route exact path="/share/deck/:id" component={SharedDeckView} />
+            {/* Player profiles work signed out too (anon-readable RPCs, like
+                shared decks) — signed in they render inside the normal app
+                shell, signed out in a standalone page. */}
+            <Route path="/profile/:id">
+              {loginState == LOGIN_OK ? (
+                <>
+                  <TopNav
+                    openArenaIdSelector={openArenaIdSelector.current}
+                    openSettings={openSettings.current}
+                  />
+                  <ContentWrapper forceOs={forceOs} />
+                </>
+              ) : (
+                <PublicProfilePage />
+              )}
+            </Route>
             <Route path="/:page">
               <>
                 <TopNav

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -90,18 +90,16 @@ function App(props: AppProps) {
   }, [matchInProgress, draftInProgress]);
 
   useEffect(() => {
-    // The token pages (/live/<token>, /share/deck/<token>) must work with no
-    // account — never bounce them to /auth or run the login flow for them.
-    if (
-      history.location.pathname.startsWith("/live/") ||
-      history.location.pathname.startsWith("/share/")
-    )
-      return;
-    // Profiles are public too, but a signed-in visitor should get the full
-    // app around them (and their collection, for crafting costs on deck
-    // lists) — so the login flow RUNS here; only the /auth bounce is
-    // skipped, leaving the signed-out standalone shell to render instead.
-    const onPublicProfile = history.location.pathname.startsWith("/profile/");
+    // The live viewer (/live/<token>) is captured as an OBS browser source —
+    // never bounce it to /auth or run the login flow for it.
+    if (history.location.pathname.startsWith("/live/")) return;
+    // Profiles and shared decks are public, but a signed-in visitor should
+    // still be recognized (collection for crafting costs, no login prompts)
+    // — so the login flow RUNS on them; only the /auth bounce is skipped,
+    // leaving the signed-out experience to render instead.
+    const onPublicProfile =
+      history.location.pathname.startsWith("/profile/") ||
+      history.location.pathname.startsWith("/share/");
     if (canLogin) {
       const autoLogin = getLocalSetting("autoLogin");
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -90,15 +90,18 @@ function App(props: AppProps) {
   }, [matchInProgress, draftInProgress]);
 
   useEffect(() => {
-    // The public pages (/live/<token>, /share/deck/<token>, /profile/<id>)
-    // must work with no account — never bounce them to /auth or run the
-    // login flow for them.
+    // The token pages (/live/<token>, /share/deck/<token>) must work with no
+    // account — never bounce them to /auth or run the login flow for them.
     if (
       history.location.pathname.startsWith("/live/") ||
-      history.location.pathname.startsWith("/share/") ||
-      history.location.pathname.startsWith("/profile/")
+      history.location.pathname.startsWith("/share/")
     )
       return;
+    // Profiles are public too, but a signed-in visitor should get the full
+    // app around them (and their collection, for crafting costs on deck
+    // lists) — so the login flow RUNS here; only the /auth bounce is
+    // skipped, leaving the signed-out standalone shell to render instead.
+    const onPublicProfile = history.location.pathname.startsWith("/profile/");
     if (canLogin) {
       const autoLogin = getLocalSetting("autoLogin");
 
@@ -114,7 +117,7 @@ function App(props: AppProps) {
       checkSession
         .then((ok) => {
           if (!ok) {
-            history.push("/auth");
+            if (!onPublicProfile) history.push("/auth");
             return undefined;
           }
           // Claim the local store BEFORE hydrating: if it belongs to another
@@ -333,21 +336,13 @@ function App(props: AppProps) {
             {/* Public (no login): shared deck page, see SharedDeckView */}
             <Route exact path="/share/deck/:id" component={SharedDeckView} />
             {/* Player profiles work signed out too (anon-readable RPCs, like
-                shared decks) — signed in they render inside the normal app
-                shell, signed out in a standalone page. */}
-            <Route path="/profile/:id">
-              {loginState == LOGIN_OK ? (
-                <>
-                  <TopNav
-                    openArenaIdSelector={openArenaIdSelector.current}
-                    openSettings={openSettings.current}
-                  />
-                  <ContentWrapper forceOs={forceOs} />
-                </>
-              ) : (
-                <PublicProfilePage />
-              )}
-            </Route>
+                shared decks): with no session this standalone page takes the
+                route; signed in it is absent from the Switch, so /profile
+                falls through to the normal app shell below — whose
+                ContentWrapper needs the /:page param this route lacks. */}
+            {loginState != LOGIN_OK ? (
+              <Route path="/profile/:id" component={PublicProfilePage} />
+            ) : null}
             <Route path="/:page">
               <>
                 <TopNav

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -163,7 +163,7 @@ function App(props: AppProps) {
         })
         .catch((e: Error) => {
           console.error(e);
-          history.push("/auth");
+          if (!onPublicProfile) history.push("/auth");
         });
     }
   }, [canLogin, history, dispatch]);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 
 import settingsIcon from "../assets/images/cog.png";
 import { ReactComponent as ShowIcon } from "../assets/images/svg/archive.svg";
@@ -60,6 +60,9 @@ export default function Auth(props: AuthProps) {
   }, []);
 
   const history = useHistory();
+  // Public pages (profiles, shared decks) send people here with a returnTo,
+  // so logging in lands them back on what they were reading.
+  const location = useLocation<{ returnTo?: string }>();
   const dispatch = useDispatch();
   const [errorMessage, setErrorMessage] = useState("");
   // Success counterpart of errorMessage — .form-error is red and fixed-height,
@@ -159,11 +162,11 @@ export default function Auth(props: AuthProps) {
 
   useEffect(() => {
     if (loginState === LOGIN_OK) {
-      history.push("/home");
+      history.push(location.state?.returnTo || "/home");
       // Data is synced by syncAll() on LOG_READ_FINISHED (account-first), so
       // no direct readCards() here.
     }
-  }, [loginState, history]);
+  }, [loginState, history, location.state]);
 
   // Shared post-auth flow: load local data and start reading the Arena log.
   const startSession = useCallback(() => {

--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -39,6 +39,7 @@ import { MatchData } from "./views/history/convertDbMatchData";
 import HistoryStats from "./views/history/HistoryStats";
 import ViewHistory from "./views/history/ViewHistory";
 import ViewHome from "./views/home/ViewHome";
+import ViewProfile from "./views/profile/ViewProfile";
 import ViewTimeline from "./views/timeline/ViewTimeline";
 
 const views = {
@@ -49,6 +50,8 @@ const views = {
   drafts: ViewDrafts,
   explore: ViewExplore,
   collection: ViewCollection,
+  // Not in the top nav; reached by clicking a player anywhere.
+  profile: ViewProfile,
 };
 
 function delay(transition: any, timeout: number): any {

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,0 +1,42 @@
+import { useHistory } from "react-router-dom";
+
+import useIsLoggedIn from "../hooks/useIsLoggedIn";
+import Section from "./ui/Section";
+
+/**
+ * "Log in to compare against your collection!" — shown on public deck and
+ * match pages to signed-out viewers, whose empty collection would otherwise
+ * make every card look uncrafted. Logging in returns to the page it was
+ * clicked from.
+ */
+export default function LoginPrompt(): JSX.Element | null {
+  const loggedIn = useIsLoggedIn();
+  const history = useHistory();
+
+  if (loggedIn) return null;
+
+  return (
+    <Section
+      style={{
+        padding: "12px 16px",
+        margin: "16px 0 0",
+        justifyContent: "center",
+      }}
+    >
+      <div className="login-prompt">
+        <span
+          className="login-prompt-link"
+          onClick={(): void =>
+            history.push("/auth", {
+              returnTo:
+                history.location.pathname + (history.location.search || ""),
+            })
+          }
+        >
+          Log in
+        </span>{" "}
+        to compare against your collection!
+      </div>
+    </Section>
+  );
+}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -24,7 +24,8 @@ export default function LoginPrompt(): JSX.Element | null {
       }}
     >
       <div className="login-prompt">
-        <span
+        <button
+          type="button"
           className="login-prompt-link"
           onClick={(): void =>
             history.push("/auth", {
@@ -34,7 +35,7 @@ export default function LoginPrompt(): JSX.Element | null {
           }
         >
           Log in
-        </span>{" "}
+        </button>{" "}
         to compare against your collection!
       </div>
     </Section>

--- a/src/components/PublicDeckDetails.tsx
+++ b/src/components/PublicDeckDetails.tsx
@@ -1,0 +1,113 @@
+import { ReactNode, useState } from "react";
+
+import compareCards from "../utils/compareCards";
+import copyToClipboard from "../utils/copyToClipboard";
+import Deck from "../utils/mtga/deck";
+import DeckColorStats from "./DeckColorStats";
+import DeckList from "./DeckList";
+import DeckManaCurve from "./DeckManaCurve";
+import DeckRarities from "./DeckRarities";
+import DeckSampleHand from "./DeckSampleHand";
+import DeckTypesStats from "./DeckTypesStats";
+import Separator from "./Separator";
+import Button from "./ui/Button";
+import Section from "./ui/Section";
+import VisualDeckView from "./views/decks/VisualDeckView";
+
+interface PublicDeckDetailsProps {
+  deck: Deck;
+  /** Craft costs read the VIEWER's collection; show only where that makes sense. */
+  showWildcards: boolean;
+  /** Rendered on the left of the controls row (a record, usually). */
+  recordSlot?: ReactNode;
+}
+
+/**
+ * The public presentation of a decklist — controls row, list, types, curve,
+ * colors, rarities and sample hand, with the visual-view toggle. Shared by
+ * the shared-deck page and the profile deck page so the two stay the same.
+ */
+export default function PublicDeckDetails({
+  deck,
+  showWildcards,
+  recordSlot,
+}: PublicDeckDetailsProps): JSX.Element {
+  const [visual, setVisual] = useState(false);
+
+  const arenaExport = (): void => {
+    // A fresh Deck: sorting in place would reorder the one being rendered.
+    const exportDeck = new Deck(
+      {},
+      deck.getMainboard().get(),
+      deck.getSideboard().get()
+    );
+    exportDeck.sortMainboard(compareCards);
+    exportDeck.sortSideboard(compareCards);
+    copyToClipboard(exportDeck.getExportArena());
+  };
+
+  if (visual) {
+    return (
+      <VisualDeckView deck={deck} setRegularView={() => setVisual(false)} />
+    );
+  }
+
+  return (
+    <div className="regular-view-grid">
+      <Section
+        style={{
+          // With no record shown there is nothing to spread apart —
+          // centered buttons instead of buttons shoved to the right.
+          justifyContent: recordSlot ? "space-between" : "center",
+          gridArea: "controls",
+        }}
+      >
+        {recordSlot}
+        <div style={{ display: "flex" }}>
+          <Button
+            style={{ margin: "16px" }}
+            className="button-simple"
+            text="Visual View"
+            onClick={() => setVisual(true)}
+          />
+          <Button
+            style={{ margin: "16px" }}
+            className="button-simple"
+            text="Export to Arena"
+            onClick={arenaExport}
+          />
+        </div>
+      </Section>
+      <Section
+        style={{
+          flexDirection: "column",
+          gridArea: "deck",
+          paddingBottom: "16px",
+          paddingLeft: "24px",
+        }}
+      >
+        <DeckList deck={deck} showWildcards={showWildcards} />
+      </Section>
+      <Section style={{ flexDirection: "column", gridArea: "types" }}>
+        <Separator>Types</Separator>
+        <DeckTypesStats deck={deck} />
+      </Section>
+      <Section style={{ flexDirection: "column", gridArea: "curves" }}>
+        <Separator>Mana Curve</Separator>
+        <DeckManaCurve deck={deck} />
+      </Section>
+      <Section style={{ flexDirection: "column", gridArea: "pies" }}>
+        <Separator>Colors</Separator>
+        <DeckColorStats deck={deck} />
+      </Section>
+      <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
+        <Separator>Cards by rarity</Separator>
+        <DeckRarities deck={deck} />
+      </Section>
+      <Section style={{ flexDirection: "column", gridArea: "hand" }}>
+        <Separator>Sample hand</Separator>
+        <DeckSampleHand deck={deck} />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/PublicDeckDetails.tsx
+++ b/src/components/PublicDeckDetails.tsx
@@ -35,12 +35,9 @@ export default function PublicDeckDetails({
   const [visual, setVisual] = useState(false);
 
   const arenaExport = (): void => {
-    // A fresh Deck: sorting in place would reorder the one being rendered.
-    const exportDeck = new Deck(
-      {},
-      deck.getMainboard().get(),
-      deck.getSideboard().get()
-    );
+    // A clone: sorting in place would reorder the one being rendered, and a
+    // rebuild from main/side would drop commanders and companions.
+    const exportDeck = deck.clone();
     exportDeck.sortMainboard(compareCards);
     exportDeck.sortSideboard(compareCards);
     copyToClipboard(exportDeck.getExportArena());

--- a/src/components/PublicLoading.tsx
+++ b/src/components/PublicLoading.tsx
@@ -1,15 +1,18 @@
 /**
- * Full-page loading state for the public pages: the round MTGATool mark
- * spinning, same as the auth screen while logging in — instead of a bare
- * "Loading…" line floating on the page background.
+ * Loading state with the round MTGATool mark spinning, same as the auth
+ * screen while logging in. Full-page by default (the standalone public
+ * shells); `inline` sits in the content flow instead, for loading sections
+ * inside the app.
  */
 export default function PublicLoading({
   label,
+  inline,
 }: {
   label?: string;
+  inline?: boolean;
 }): JSX.Element {
   return (
-    <div className="public-loading">
+    <div className={`public-loading${inline ? " inline" : ""}`}>
       <div className="public-loading-icon" />
       {label ? <div className="public-loading-label">{label}</div> : null}
     </div>

--- a/src/components/PublicLoading.tsx
+++ b/src/components/PublicLoading.tsx
@@ -1,0 +1,17 @@
+/**
+ * Full-page loading state for the public pages: the round MTGATool mark
+ * spinning, same as the auth screen while logging in — instead of a bare
+ * "Loading…" line floating on the page background.
+ */
+export default function PublicLoading({
+  label,
+}: {
+  label?: string;
+}): JSX.Element {
+  return (
+    <div className="public-loading">
+      <div className="public-loading-icon" />
+      {label ? <div className="public-loading-label">{label}</div> : null}
+    </div>
+  );
+}

--- a/src/components/PublicLoading.tsx
+++ b/src/components/PublicLoading.tsx
@@ -12,8 +12,13 @@ export default function PublicLoading({
   inline?: boolean;
 }): JSX.Element {
   return (
-    <div className={`public-loading${inline ? " inline" : ""}`}>
-      <div className="public-loading-icon" />
+    <div
+      className={`public-loading${inline ? " inline" : ""}`}
+      role="status"
+      aria-live="polite"
+      aria-label={label || "Loading"}
+    >
+      <div className="public-loading-icon" aria-hidden="true" />
       {label ? <div className="public-loading-label">{label}</div> : null}
     </div>
   );

--- a/src/components/PublicTopBar.tsx
+++ b/src/components/PublicTopBar.tsx
@@ -1,0 +1,43 @@
+import { useHistory } from "react-router-dom";
+
+import logoBig from "../assets/images/logo_big.png";
+import openExternal from "../utils/openExternal";
+import Button from "./ui/Button";
+
+/**
+ * Slim chrome for the signed-out public pages: brand on the left, two honest
+ * actions on the right. Deliberately NOT the app's TopNav with placeholders —
+ * a bar full of tabs that all bounce to a login wall reads as broken; this
+ * one only offers what actually works signed out.
+ */
+export default function PublicTopBar(): JSX.Element {
+  const history = useHistory();
+
+  return (
+    <div className="public-top-bar">
+      <div
+        className="public-top-bar-brand"
+        onClick={(): void => openExternal("https://mtgatool.com")}
+      >
+        <img src={logoBig} alt="MTG Arena Tool" />
+      </div>
+      <div className="public-top-bar-actions">
+        <Button
+          className="button-simple"
+          text="Log in"
+          onClick={(): void =>
+            history.push("/auth", {
+              returnTo:
+                history.location.pathname + (history.location.search || ""),
+            })
+          }
+        />
+        <Button
+          className="button-simple"
+          text="Get the tracker"
+          onClick={(): void => openExternal("https://mtgatool.com")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/PublicTopBar.tsx
+++ b/src/components/PublicTopBar.tsx
@@ -15,12 +15,13 @@ export default function PublicTopBar(): JSX.Element {
 
   return (
     <div className="public-top-bar">
-      <div
+      <button
+        type="button"
         className="public-top-bar-brand"
         onClick={(): void => openExternal("https://mtgatool.com")}
       >
         <img src={logoBig} alt="MTG Arena Tool" />
-      </div>
+      </button>
       <div className="public-top-bar-actions">
         <Button
           className="button-simple"

--- a/src/components/PublicTopBar.tsx
+++ b/src/components/PublicTopBar.tsx
@@ -2,7 +2,6 @@ import { useHistory } from "react-router-dom";
 
 import logoBig from "../assets/images/logo_big.png";
 import openExternal from "../utils/openExternal";
-import Button from "./ui/Button";
 
 /**
  * Slim chrome for the signed-out public pages: brand on the left, two honest
@@ -23,21 +22,27 @@ export default function PublicTopBar(): JSX.Element {
         <img src={logoBig} alt="MTG Arena Tool" />
       </button>
       <div className="public-top-bar-actions">
-        <Button
+        {/* Native buttons: the shared Button renders a div and offers no
+            keyboard semantics. .button-simple styles apply the same. */}
+        <button
+          type="button"
           className="button-simple"
-          text="Log in"
           onClick={(): void =>
             history.push("/auth", {
               returnTo:
                 history.location.pathname + (history.location.search || ""),
             })
           }
-        />
-        <Button
+        >
+          Log in
+        </button>
+        <button
+          type="button"
           className="button-simple"
-          text="Get the tracker"
           onClick={(): void => openExternal("https://mtgatool.com")}
-        />
+        >
+          Get the tracker
+        </button>
       </div>
     </div>
   );

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 import logoBig from "../assets/images/logo_big.png";
 import { DEFAULT_AVATAR, DEFAULT_TILE } from "../constants";
@@ -27,7 +27,6 @@ import PlayerMatchesSection from "./views/profile/PlayerMatchesSection";
  */
 export default function SharedDeckView(): JSX.Element {
   const params = useParams<{ id: string }>();
-  const history = useHistory();
   const [dbReady, setDbReady] = useState(false);
   const [dbFailed, setDbFailed] = useState(false);
   const [payload, setPayload] = useState<SharedDeckPayload | null>(null);
@@ -147,24 +146,24 @@ export default function SharedDeckView(): JSX.Element {
               />
               <div className="shared-deck-title">
                 <div className="shared-deck-name">{snapshot.name}</div>
-                <div
-                  className={`shared-deck-owner${
-                    ownerProfile ? " has-profile" : ""
-                  }`}
-                  onClick={
-                    ownerProfile
-                      ? (): void =>
-                          history.push(
-                            `/profile/${encodeURIComponent(ownerProfile)}`
-                          )
-                      : undefined
-                  }
-                >
-                  by {ownerName}
-                  {owner && owner.supporter_tier > 0 ? (
-                    <SupporterBadge tier={owner.supporter_tier} />
-                  ) : null}
-                </div>
+                {ownerProfile ? (
+                  <Link
+                    className="shared-deck-owner has-profile"
+                    to={`/profile/${encodeURIComponent(ownerProfile)}`}
+                  >
+                    by {ownerName}
+                    {owner && owner.supporter_tier > 0 ? (
+                      <SupporterBadge tier={owner.supporter_tier} />
+                    ) : null}
+                  </Link>
+                ) : (
+                  <div className="shared-deck-owner">
+                    by {ownerName}
+                    {owner && owner.supporter_tier > 0 ? (
+                      <SupporterBadge tier={owner.supporter_tier} />
+                    ) : null}
+                  </div>
+                )}
               </div>
             </div>
             <div className="flex-item">

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -14,6 +14,7 @@ import DeckColorsBar from "./DeckColorsBar";
 import LoginPrompt from "./LoginPrompt";
 import ManaCost from "./ManaCost";
 import PublicDeckDetails from "./PublicDeckDetails";
+import PublicLoading from "./PublicLoading";
 import SupporterBadge from "./SupporterBadge";
 import PlayerMatchesSection from "./views/profile/PlayerMatchesSection";
 
@@ -116,7 +117,7 @@ export default function SharedDeckView(): JSX.Element {
   }
 
   if (!payload || !dbReady || !snapshot) {
-    return <div className="shared-deck-missing">Loading deck…</div>;
+    return <PublicLoading label="Loading deck…" />;
   }
 
   const { owner } = payload;

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 
 import logoBig from "../assets/images/logo_big.png";
 import { DEFAULT_AVATAR, DEFAULT_TILE } from "../constants";
@@ -7,24 +7,14 @@ import { fetchSharedDeck, SharedDeckPayload } from "../data/sharedDecks";
 import { useCards } from "../hooks/useCard";
 import { useCardArtCrop } from "../hooks/useCardImage";
 import cardsDb from "../utils/cardsDb/cardsDbClient";
-import compareCards from "../utils/compareCards";
-import copyToClipboard from "../utils/copyToClipboard";
 import Colors from "../utils/mtga/colors";
 import Deck from "../utils/mtga/deck";
 import openExternal from "../utils/openExternal";
 import DeckColorsBar from "./DeckColorsBar";
-import DeckColorStats from "./DeckColorStats";
-import DeckList from "./DeckList";
-import DeckManaCurve from "./DeckManaCurve";
-import DeckRarities from "./DeckRarities";
-import DeckSampleHand from "./DeckSampleHand";
-import DeckTypesStats from "./DeckTypesStats";
 import ManaCost from "./ManaCost";
-import Separator from "./Separator";
+import PublicDeckDetails from "./PublicDeckDetails";
 import SupporterBadge from "./SupporterBadge";
-import Button from "./ui/Button";
-import Section from "./ui/Section";
-import VisualDeckView from "./views/decks/VisualDeckView";
+import PlayerMatchesSection from "./views/profile/PlayerMatchesSection";
 
 /**
  * Public shared-deck page (app.mtgatool.com/share/deck/<token>) — what a
@@ -35,11 +25,11 @@ import VisualDeckView from "./views/decks/VisualDeckView";
  */
 export default function SharedDeckView(): JSX.Element {
   const params = useParams<{ id: string }>();
+  const history = useHistory();
   const [dbReady, setDbReady] = useState(false);
   const [dbFailed, setDbFailed] = useState(false);
   const [payload, setPayload] = useState<SharedDeckPayload | null>(null);
   const [missing, setMissing] = useState(false);
-  const [visual, setVisual] = useState(false);
 
   // Card names/art need the cards database; load it without any login. A
   // failure must surface — otherwise the page sits on "Loading" forever.
@@ -100,19 +90,6 @@ export default function SharedDeckView(): JSX.Element {
 
   const deckArt = useCardArtCrop(snapshot?.deckTileId || DEFAULT_TILE);
 
-  const arenaExport = (): void => {
-    // A fresh Deck: sorting in place would reorder the memoized one the page
-    // is rendering.
-    const exportDeck = new Deck(
-      {},
-      snapshot?.mainDeck || [],
-      snapshot?.sideboard || []
-    );
-    exportDeck.sortMainboard(compareCards);
-    exportDeck.sortSideboard(compareCards);
-    copyToClipboard(exportDeck.getExportArena());
-  };
-
   if (missing) {
     return (
       <div className="shared-deck-missing">
@@ -142,6 +119,7 @@ export default function SharedDeckView(): JSX.Element {
   }
 
   const { owner } = payload;
+  const ownerProfile = owner?.username || null;
   const ownerName = owner?.username || "A Planeswalker";
   const wr = payload.winrate;
   const games = wr ? wr.wins + wr.losses : 0;
@@ -167,7 +145,19 @@ export default function SharedDeckView(): JSX.Element {
               />
               <div className="shared-deck-title">
                 <div className="shared-deck-name">{snapshot.name}</div>
-                <div className="shared-deck-owner">
+                <div
+                  className={`shared-deck-owner${
+                    ownerProfile ? " has-profile" : ""
+                  }`}
+                  onClick={
+                    ownerProfile
+                      ? (): void =>
+                          history.push(
+                            `/profile/${encodeURIComponent(ownerProfile)}`
+                          )
+                      : undefined
+                  }
+                >
                   by {ownerName}
                   {owner && owner.supporter_tier > 0 ? (
                     <SupporterBadge tier={owner.supporter_tier} />
@@ -184,85 +174,43 @@ export default function SharedDeckView(): JSX.Element {
           </div>
         </div>
 
-        {visual ? (
-          <VisualDeckView deck={deck} setRegularView={() => setVisual(false)} />
-        ) : (
-          <div className="regular-view-grid">
-            <Section
-              style={{
-                // With no record shown there is nothing to spread apart —
-                // centered buttons instead of buttons shoved to the right.
-                justifyContent: showRecord ? "space-between" : "center",
-                gridArea: "controls",
-              }}
-            >
-              {showRecord && wr ? (
-                <div
-                  className="shared-deck-record"
-                  title={`${wr.wins} wins, ${wr.losses} losses`}
+        <PublicDeckDetails
+          deck={deck}
+          showWildcards={false}
+          recordSlot={
+            showRecord && wr ? (
+              <div
+                className="shared-deck-record"
+                title={`${wr.wins} wins, ${wr.losses} losses`}
+              >
+                <span className="record">{`${wr.wins}-${wr.losses}`}</span>
+                <span
+                  className="percent"
+                  style={{
+                    color:
+                      wr.wins / games >= 0.5
+                        ? "var(--color-g)"
+                        : "var(--color-r)",
+                  }}
                 >
-                  <span className="record">{`${wr.wins}-${wr.losses}`}</span>
-                  <span
-                    className="percent"
-                    style={{
-                      color:
-                        wr.wins / games >= 0.5
-                          ? "var(--color-g)"
-                          : "var(--color-r)",
-                    }}
-                  >
-                    {`${((wr.wins / games) * 100).toFixed(0)}%`}
-                  </span>
-                  <span className="record-label">win rate</span>
-                </div>
-              ) : null}
-              <div style={{ display: "flex" }}>
-                <Button
-                  style={{ margin: "16px" }}
-                  className="button-simple"
-                  text="Visual View"
-                  onClick={() => setVisual(true)}
-                />
-                <Button
-                  style={{ margin: "16px" }}
-                  className="button-simple"
-                  text="Export to Arena"
-                  onClick={arenaExport}
-                />
+                  {`${((wr.wins / games) * 100).toFixed(0)}%`}
+                </span>
+                <span className="record-label">win rate</span>
               </div>
-            </Section>
-            <Section
-              style={{
-                flexDirection: "column",
-                gridArea: "deck",
-                paddingBottom: "16px",
-                paddingLeft: "24px",
-              }}
-            >
-              <DeckList deck={deck} showWildcards={false} />
-            </Section>
-            <Section style={{ flexDirection: "column", gridArea: "types" }}>
-              <Separator>Types</Separator>
-              <DeckTypesStats deck={deck} />
-            </Section>
-            <Section style={{ flexDirection: "column", gridArea: "curves" }}>
-              <Separator>Mana Curve</Separator>
-              <DeckManaCurve deck={deck} />
-            </Section>
-            <Section style={{ flexDirection: "column", gridArea: "pies" }}>
-              <Separator>Colors</Separator>
-              <DeckColorStats deck={deck} />
-            </Section>
-            <Section style={{ flexDirection: "column", gridArea: "rarities" }}>
-              <Separator>Cards by rarity</Separator>
-              <DeckRarities deck={deck} />
-            </Section>
-            <Section style={{ flexDirection: "column", gridArea: "hand" }}>
-              <Separator>Sample hand</Separator>
-              <DeckSampleHand deck={deck} />
-            </Section>
-          </div>
-        )}
+            ) : undefined
+          }
+        />
+
+        {/* The deck's latest matches, when the owner is public. Same
+            component as the profile pages: last five for everyone, the rest
+            behind the Patreon pitch. */}
+        {owner?.username && payload.deck_id ? (
+          <PlayerMatchesSection
+            id={owner.username}
+            deckId={payload.deck_id}
+            title="Recent matches with this deck"
+          />
+        ) : null}
 
         <div
           className="shared-deck-footer"

--- a/src/components/SharedDeckView.tsx
+++ b/src/components/SharedDeckView.tsx
@@ -11,6 +11,7 @@ import Colors from "../utils/mtga/colors";
 import Deck from "../utils/mtga/deck";
 import openExternal from "../utils/openExternal";
 import DeckColorsBar from "./DeckColorsBar";
+import LoginPrompt from "./LoginPrompt";
 import ManaCost from "./ManaCost";
 import PublicDeckDetails from "./PublicDeckDetails";
 import SupporterBadge from "./SupporterBadge";
@@ -173,6 +174,8 @@ export default function SharedDeckView(): JSX.Element {
             </div>
           </div>
         </div>
+
+        <LoginPrompt />
 
         <PublicDeckDetails
           deck={deck}

--- a/src/components/WhatsNewPopup.tsx
+++ b/src/components/WhatsNewPopup.tsx
@@ -23,6 +23,10 @@ interface WhatsNewItem {
  */
 const NEW_IN_THIS_VERSION: WhatsNewItem[] = [
   {
+    title: "Player profiles",
+    body: "Click any player on the Home top-ranked feed to open their public profile: current ranks with their record over the last 30 days, the formats they play, and their latest matches — each opening a public match page with the deck they ran and the action log. Standard-tier Patreon supporters can browse anyone's full match history and their top decks with win rates. Private mode keeps you out of all of it, and Settings lets you choose which Arena account your profile shows.",
+  },
+  {
     title: "Share your decks",
     body: "Decks have a Share button now: it copies a public link anyone can open — no account needed — showing the decklist, mana curve, types, colors and sample hands, plus your win rate with the deck if you choose to show it (and your Patreon badge, supporters). Stop sharing any time and the link dies.",
   },

--- a/src/components/popups/PatreonInfo.tsx
+++ b/src/components/popups/PatreonInfo.tsx
@@ -8,12 +8,16 @@ interface DialogProps {
   closeCallback?: () => void;
 }
 
-/** Perk list, each line accented with one of the supporter tier colours. */
+/**
+ * Perk list. `accent` picks a dot colour from the tier palette for variety —
+ * it is decoration, NOT the tier that unlocks the perk (the profile perks
+ * unlock at Standard).
+ */
 const PERKS = [
-  { text: "Browse the full match history on player profiles", tier: 3 },
-  { text: "See other players' decks and their records", tier: 4 },
-  { text: "Access global cards winrate statistics", tier: 2 },
-  { text: "Get priority support", tier: 1 },
+  { text: "Browse the full match history on player profiles", accent: 3 },
+  { text: "See other players' decks and their records", accent: 4 },
+  { text: "Access global cards winrate statistics", accent: 2 },
+  { text: "Get priority support", accent: 1 },
 ];
 
 /** Patreon marks floating around the header band. */
@@ -61,8 +65,10 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
         className="popup-div-nopadding"
         style={{
           height: `${open * 470}px`,
+          maxHeight: "92vh",
           width: `${open * 520}px`,
-          overflow: "initial",
+          overflowY: "auto",
+          overflowX: "hidden",
         }}
         onClick={(e): void => {
           e.stopPropagation();
@@ -89,7 +95,7 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
             <div className="patreon-perk" key={perk.text}>
               <div
                 className="patreon-perk-dot"
-                style={{ backgroundColor: TIERS[perk.tier].top }}
+                style={{ backgroundColor: TIERS[perk.accent].top }}
               />
               <div>{perk.text}</div>
             </div>
@@ -98,9 +104,11 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
             Supporting also helps us develop new amazing features! See our
             Patreon page to learn more about upcoming and planned perks:
           </div>
-          <div
+          <button
+            type="button"
             className="patreon_link_thin"
             title="Open on browser"
+            aria-label="Become a patron on Patreon"
             onClick={(): void =>
               openExternal("https://www.patreon.com/cw/mtgatool")
             }

--- a/src/components/popups/PatreonInfo.tsx
+++ b/src/components/popups/PatreonInfo.tsx
@@ -1,10 +1,29 @@
 import { useCallback, useEffect, useState } from "react";
 
 import openExternal from "../../utils/openExternal";
+import PatreonLogo from "../PatreonLogo";
+import { TIERS } from "../SupporterTierIcon";
 
 interface DialogProps {
   closeCallback?: () => void;
 }
+
+/** Perk list, each line accented with one of the supporter tier colours. */
+const PERKS = [
+  { text: "Browse the full match history on player profiles", tier: 3 },
+  { text: "See other players' decks and their records", tier: 4 },
+  { text: "Access global cards winrate statistics", tier: 2 },
+  { text: "Get priority support", tier: 1 },
+];
+
+/** Patreon marks floating around the header band. */
+const FLOATERS: React.CSSProperties[] = [
+  { width: "42px", top: "-10px", left: "24px", transform: "rotate(-16deg)" },
+  { width: "26px", top: "34px", left: "84px", transform: "rotate(12deg)" },
+  { width: "58px", top: "10px", right: "-14px", transform: "rotate(20deg)" },
+  { width: "22px", top: "-6px", right: "92px", transform: "rotate(-24deg)" },
+  { width: "30px", bottom: "-12px", left: "180px", transform: "rotate(8deg)" },
+];
 
 export default function PatreonInfo(props: DialogProps): JSX.Element {
   const { closeCallback } = props;
@@ -41,7 +60,7 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
       <div
         className="popup-div-nopadding"
         style={{
-          height: `${open * 340}px`,
+          height: `${open * 470}px`,
           width: `${open * 520}px`,
           overflow: "initial",
         }}
@@ -50,6 +69,14 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
         }}
       >
         <div className="patreon-info-pop-top">
+          {FLOATERS.map((style, i) => (
+            <PatreonLogo
+              // eslint-disable-next-line react/no-array-index-key
+              key={`patreon-float-${i}`}
+              className="patreon-float"
+              style={style}
+            />
+          ))}
           <div
             style={{ color: "var(--color-text-hover)" }}
             className="message-sub"
@@ -58,25 +85,24 @@ export default function PatreonInfo(props: DialogProps): JSX.Element {
           </div>
         </div>
         <div className="patreon-info-pop-bottom">
-          <div className="patreon-info-text">
-            Synchronize your data across multiple devices
-          </div>
-          <div className="patreon-info-text">
-            Access global cards winrate statistics
-          </div>
-          <div className="patreon-info-text">Get priority Support</div>
-          <div className="patreon-info-text">
-            Help us develop new amazing features!
-          </div>
+          {PERKS.map((perk) => (
+            <div className="patreon-perk" key={perk.text}>
+              <div
+                className="patreon-perk-dot"
+                style={{ backgroundColor: TIERS[perk.tier].top }}
+              />
+              <div>{perk.text}</div>
+            </div>
+          ))}
           <div className="patreon-desc-text">
-            See our patreon page to learn more about upcoming and planned
-            features:
+            Supporting also helps us develop new amazing features! See our
+            Patreon page to learn more about upcoming and planned perks:
           </div>
           <div
-            className="patreon-link-thin"
+            className="patreon_link_thin"
             title="Open on browser"
             onClick={(): void =>
-              openExternal("https://www.patreon.com/mtgatool")
+              openExternal("https://www.patreon.com/cw/mtgatool")
             }
           />
         </div>

--- a/src/components/views/home/BestRanksFeed.tsx
+++ b/src/components/views/home/BestRanksFeed.tsx
@@ -40,7 +40,15 @@ function DrawConstructedRank(
         }}
       />
       <div className="rank-name-container">
-        <div className="rank-name" onClick={() => openProfile(name || uuid)}>
+        <div
+          className="rank-name"
+          role="button"
+          tabIndex={0}
+          onClick={() => openProfile(name || uuid)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") openProfile(name || uuid);
+          }}
+        >
           {cleanUsername(name || "-")}
         </div>
       </div>
@@ -93,7 +101,15 @@ function DrawLimitedRank(
         }}
       />
       <div className="rank-name-container">
-        <div className="rank-name" onClick={() => openProfile(name || uuid)}>
+        <div
+          className="rank-name"
+          role="button"
+          tabIndex={0}
+          onClick={() => openProfile(name || uuid)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") openProfile(name || uuid);
+          }}
+        >
           {cleanUsername(name || "-")}
         </div>
       </div>

--- a/src/components/views/home/BestRanksFeed.tsx
+++ b/src/components/views/home/BestRanksFeed.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { useEffect, useRef, useState } from "react";
+import { useHistory } from "react-router-dom";
 
 import { DEFAULT_AVATAR } from "../../../constants";
 import { getLatestRanks } from "../../../data/publicProfiles";
@@ -8,9 +9,13 @@ import RankIcon from "../../RankIcon";
 import DbRankInfo from "./DbRankInfo";
 import { sortConstructedRanks, sortLimitedRanks } from "./sortRanks";
 
-function DrawConstructedRank(props: DbRankInfo & { pos: number }) {
+function DrawConstructedRank(
+  props: DbRankInfo & { pos: number; openProfile: (arenaId: string) => void }
+) {
   const {
     pos,
+    uuid,
+    openProfile,
     name,
     avatar,
     constructedClass,
@@ -35,7 +40,9 @@ function DrawConstructedRank(props: DbRankInfo & { pos: number }) {
         }}
       />
       <div className="rank-name-container">
-        <div className="rank-name">{cleanUsername(name || "-")}</div>
+        <div className="rank-name" onClick={() => openProfile(name || uuid)}>
+          {cleanUsername(name || "-")}
+        </div>
       </div>
       <div className="rank-icon">
         <div className="rank-position">
@@ -55,9 +62,13 @@ function DrawConstructedRank(props: DbRankInfo & { pos: number }) {
   );
 }
 
-function DrawLimitedRank(props: DbRankInfo & { pos: number }) {
+function DrawLimitedRank(
+  props: DbRankInfo & { pos: number; openProfile: (arenaId: string) => void }
+) {
   const {
     pos,
+    uuid,
+    openProfile,
     name,
     avatar,
     limitedClass,
@@ -82,7 +93,9 @@ function DrawLimitedRank(props: DbRankInfo & { pos: number }) {
         }}
       />
       <div className="rank-name-container">
-        <div className="rank-name">{cleanUsername(name || "-")}</div>
+        <div className="rank-name" onClick={() => openProfile(name || uuid)}>
+          {cleanUsername(name || "-")}
+        </div>
       </div>
       <div className="rank-icon">
         <div className="rank-position">
@@ -111,7 +124,15 @@ function DrawLoadingRank() {
 const emptyList = new Array(10).fill(0);
 
 export default function BestRanksFeed() {
+  const history = useHistory();
   const [allRanks, setAllRanks] = useState<DbRankInfo[]>([]);
+
+  // Prefer the username in the URL — /profile/manwe reads better and stays
+  // stable across account switches; ViewProfile still resolves arena ids for
+  // the rows that never made a profile.
+  const openProfile = (id: string): void => {
+    history.push(`/profile/${encodeURIComponent(id)}`);
+  };
 
   const isLoadingRef = useRef(false);
 
@@ -138,6 +159,7 @@ export default function BestRanksFeed() {
               <DrawConstructedRank
                 key={`constructed-best-${r.uuid}`}
                 pos={i + 1}
+                openProfile={openProfile}
                 {...r}
               />
             ))}
@@ -150,6 +172,7 @@ export default function BestRanksFeed() {
               <DrawLimitedRank
                 key={`limited-best-${r.uuid}`}
                 pos={i + 1}
+                openProfile={openProfile}
                 {...r}
               />
             ))}

--- a/src/components/views/home/BestRanksFeed.tsx
+++ b/src/components/views/home/BestRanksFeed.tsx
@@ -40,17 +40,13 @@ function DrawConstructedRank(
         }}
       />
       <div className="rank-name-container">
-        <div
+        <button
+          type="button"
           className="rank-name"
-          role="button"
-          tabIndex={0}
           onClick={() => openProfile(name || uuid)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") openProfile(name || uuid);
-          }}
         >
           {cleanUsername(name || "-")}
-        </div>
+        </button>
       </div>
       <div className="rank-icon">
         <div className="rank-position">
@@ -101,17 +97,13 @@ function DrawLimitedRank(
         }}
       />
       <div className="rank-name-container">
-        <div
+        <button
+          type="button"
           className="rank-name"
-          role="button"
-          tabIndex={0}
           onClick={() => openProfile(name || uuid)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") openProfile(name || uuid);
-          }}
         >
           {cleanUsername(name || "-")}
-        </div>
+        </button>
       </div>
       <div className="rank-icon">
         <div className="rank-position">

--- a/src/components/views/profile/PlayerMatchesSection.tsx
+++ b/src/components/views/profile/PlayerMatchesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import {
@@ -38,9 +38,13 @@ export default function PlayerMatchesSection({
   const [page, setPage] = useState<PlayerMatchesPage | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [showPatreonPopup, setShowPatreonPopup] = useState(false);
+  // Guards both fetches against navigation: a slow answer for the previous
+  // profile or deck must not land in the new one's list.
+  const requestKey = useRef("");
 
   useEffect(() => {
     let cancelled = false;
+    requestKey.current = `${id}|${deckId ?? ""}`;
     setPage(null);
     getPlayerMatches({ arenaId: id }, PUBLIC_MATCHES, 0, deckId)
       .then(
@@ -57,6 +61,7 @@ export default function PlayerMatchesSection({
 
   const loadMore = useCallback(() => {
     if (!page || loadingMore) return;
+    const key = `${id}|${deckId ?? ""}`;
     setLoadingMore(true);
     getPlayerMatches({ arenaId: id }, HISTORY_PAGE, page.matches.length, deckId)
       .then(
@@ -70,6 +75,7 @@ export default function PlayerMatchesSection({
           )
       )
       .then((p) => {
+        if (requestKey.current !== key) return;
         setLoadingMore(false);
         if (p && p.matches.length > 0) {
           setPage({

--- a/src/components/views/profile/PlayerMatchesSection.tsx
+++ b/src/components/views/profile/PlayerMatchesSection.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+
+import {
+  getPlayerMatches,
+  PlayerMatchesPage,
+  PlayerMatchRow,
+} from "../../../data/publicProfiles";
+import PatreonInfo from "../../popups/PatreonInfo";
+import Button from "../../ui/Button";
+import Section from "../../ui/Section";
+import ProfileListItemMatch from "./ProfileListItemMatch";
+
+/** How many matches everyone can see; the server enforces the same number. */
+const PUBLIC_MATCHES = 5;
+/** Page size for supporters browsing past the public window. */
+const HISTORY_PAGE = 25;
+
+interface PlayerMatchesSectionProps {
+  /** Profile identifier — username or arena id — for lookups and match links. */
+  id: string;
+  /** Restrict to one deck (Arena deck id). */
+  deckId?: string;
+  title?: string;
+}
+
+/**
+ * A player's public match list: the last five for everyone, pageable for
+ * Standard-tier patrons, the Patreon pitch for everyone else. Used by the
+ * profile page, the profile deck page and the shared-deck page.
+ */
+export default function PlayerMatchesSection({
+  id,
+  deckId,
+  title = "Recent matches",
+}: PlayerMatchesSectionProps): JSX.Element | null {
+  const history = useHistory();
+  const [page, setPage] = useState<PlayerMatchesPage | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [showPatreonPopup, setShowPatreonPopup] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPage(null);
+    getPlayerMatches({ arenaId: id }, PUBLIC_MATCHES, 0, deckId)
+      .then(
+        (p) =>
+          p ?? getPlayerMatches({ username: id }, PUBLIC_MATCHES, 0, deckId)
+      )
+      .then((p) => {
+        if (!cancelled && p) setPage(p);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, deckId]);
+
+  const loadMore = useCallback(() => {
+    if (!page || loadingMore) return;
+    setLoadingMore(true);
+    getPlayerMatches({ arenaId: id }, HISTORY_PAGE, page.matches.length, deckId)
+      .then(
+        (p) =>
+          p ??
+          getPlayerMatches(
+            { username: id },
+            HISTORY_PAGE,
+            page.matches.length,
+            deckId
+          )
+      )
+      .then((p) => {
+        setLoadingMore(false);
+        if (p && p.matches.length > 0) {
+          setPage({
+            ...p,
+            matches: [...page.matches, ...p.matches],
+          });
+        }
+      });
+  }, [id, deckId, page, loadingMore]);
+
+  const openMatch = useCallback(
+    (row: PlayerMatchRow) => {
+      history.push(
+        `/profile/${encodeURIComponent(id)}/match/${encodeURIComponent(
+          row.match_id
+        )}`
+      );
+    },
+    [history, id]
+  );
+
+  if (!page || page.total === 0) return null;
+
+  const hasMore = page.matches.length < page.total;
+
+  return (
+    <Section
+      style={{ flexDirection: "column", padding: "16px", margin: "16px 0 0" }}
+    >
+      <div className="profile-section-title">{title}</div>
+      {page.matches.map((row) => (
+        <ProfileListItemMatch
+          row={row}
+          key={`player-match-${row.match_id}`}
+          openMatchCallback={openMatch}
+        />
+      ))}
+      {hasMore ? (
+        <Button
+          style={{ margin: "16px auto 0" }}
+          text={
+            loadingMore
+              ? "Loading..."
+              : `Show more (${page.matches.length} of ${page.total})`
+          }
+          // Full history is a Standard-tier perk; everyone else gets the
+          // upgrade pitch instead of another page.
+          onClick={
+            page.full_access ? loadMore : (): void => setShowPatreonPopup(true)
+          }
+          disabled={loadingMore}
+        />
+      ) : null}
+      {showPatreonPopup ? (
+        <PatreonInfo closeCallback={(): void => setShowPatreonPopup(false)} />
+      ) : null}
+    </Section>
+  );
+}

--- a/src/components/views/profile/PlayerMatchesSection.tsx
+++ b/src/components/views/profile/PlayerMatchesSection.tsx
@@ -46,6 +46,9 @@ export default function PlayerMatchesSection({
     let cancelled = false;
     requestKey.current = `${id}|${deckId ?? ""}`;
     setPage(null);
+    // A discarded stale continuation never clears this; do it here or the
+    // new list can never load more.
+    setLoadingMore(false);
     getPlayerMatches({ arenaId: id }, PUBLIC_MATCHES, 0, deckId)
       .then(
         (p) =>

--- a/src/components/views/profile/ProfileDeckRow.tsx
+++ b/src/components/views/profile/ProfileDeckRow.tsx
@@ -46,7 +46,7 @@ export default function ProfileDeckRow({
       playerId: "",
       deckHash: row.id,
       matches: {},
-      lastUsed: new Date(row.last_played).getTime(),
+      lastUsed: row.last_played ? new Date(row.last_played).getTime() : 0,
       stats: {
         gameWins: 0,
         gameLosses: 0,

--- a/src/components/views/profile/ProfileDeckRow.tsx
+++ b/src/components/views/profile/ProfileDeckRow.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+
+import { DEFAULT_TILE } from "../../../constants";
+import { PlayerDeckRow } from "../../../data/publicProfiles";
+import { useCards } from "../../../hooks/useCard";
+import { StatsDeck } from "../../../types/dbTypes";
+import Deck from "../../../utils/mtga/deck";
+import vodiFn from "../../../utils/voidfn";
+import DecksArtViewRow from "../../DecksArtViewRow";
+
+interface ProfileDeckRowProps {
+  row: PlayerDeckRow;
+  clickDeck: (row: PlayerDeckRow) => void;
+}
+
+/**
+ * One of a profile's decks, drawn with the same art row the Home tab's "Top
+ * decks" uses, record included.
+ */
+export default function ProfileDeckRow({
+  row,
+  clickDeck,
+}: ProfileDeckRowProps): JSX.Element {
+  const pd = row.deck ?? {};
+
+  // Colors are read off the deck's lands, which is a card lookup — empty on
+  // a cold public page. Prefetch and rebuild once the cards land (same as
+  // the Home tab's top decks).
+  const grpIds = useMemo(
+    () => [...new Set((pd.mainDeck ?? []).map((c) => c.id))],
+    [pd.mainDeck]
+  );
+  const resolvedCards = useCards(grpIds);
+
+  const statsDeck: StatsDeck = useMemo(() => {
+    const deck = new Deck(pd);
+    return {
+      id: row.id,
+      name: pd.name || "Unknown deck",
+      deckTileId: pd.deckTileId || DEFAULT_TILE,
+      mainDeck: pd.mainDeck || [],
+      sideboard: pd.sideboard || [],
+      colors: deck.colors.getBits() || pd.colors || 0,
+      playerId: "",
+      deckHash: row.id,
+      matches: {},
+      lastUsed: new Date(row.last_played).getTime(),
+      stats: {
+        gameWins: 0,
+        gameLosses: 0,
+        matchWins: row.wins,
+        matchLosses: row.games - row.wins,
+      },
+      totalGames: row.games,
+      cardWinrates: {},
+      winrate: row.games ? (row.wins / row.games) * 100 : 0,
+    };
+    // resolvedCards is the point: the colors above are only right once the
+    // lookups have come back.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [row, pd, resolvedCards]);
+
+  return (
+    <DecksArtViewRow
+      deck={statsDeck}
+      clickDeck={(): void => clickDeck(row)}
+      hidden={false}
+      hide={vodiFn}
+      unhide={vodiFn}
+      showArchive={false}
+    />
+  );
+}

--- a/src/components/views/profile/ProfileDeckRow.tsx
+++ b/src/components/views/profile/ProfileDeckRow.tsx
@@ -40,7 +40,9 @@ export default function ProfileDeckRow({
       deckTileId: pd.deckTileId || DEFAULT_TILE,
       mainDeck: pd.mainDeck || [],
       sideboard: pd.sideboard || [],
-      colors: deck.colors.getBits() || pd.colors || 0,
+      colors:
+        deck.colors.getBits() ||
+        (typeof pd.colors === "number" ? pd.colors : 0),
       playerId: "",
       deckHash: row.id,
       matches: {},

--- a/src/components/views/profile/ProfileListItemMatch.tsx
+++ b/src/components/views/profile/ProfileListItemMatch.tsx
@@ -1,0 +1,151 @@
+import _ from "lodash";
+import { useMemo } from "react";
+
+import { DEFAULT_TILE } from "../../../constants";
+import { PlayerMatchRow } from "../../../data/publicProfiles";
+import { useCards } from "../../../hooks/useCard";
+import { toMMSS } from "../../../utils/dateTo";
+import getEventPrettyName from "../../../utils/getEventPrettyName";
+import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
+import isLimitedEventId from "../../../utils/isLimitedEventId";
+import Colors from "../../../utils/mtga/colors";
+import timeAgo from "../../../utils/timeAgo";
+import {
+  Column,
+  FlexBottom,
+  FlexTop,
+  HoverTile,
+  ListItem,
+} from "../../ListItem";
+import ManaCost from "../../ManaCost";
+import RankIcon from "../../RankIcon";
+import RankSmall from "../../RankSmall";
+
+interface ProfileListItemMatchProps {
+  row: PlayerMatchRow;
+  openMatchCallback: (row: PlayerMatchRow) => void;
+}
+
+/**
+ * A public profile's match row, styled like the History tab's ListItemMatch.
+ * Differs where the data must: no upload/delete controls, and the opponent
+ * side shows rank and colors but never a name.
+ */
+export default function ProfileListItemMatch({
+  row,
+  openMatchCallback,
+}: ProfileListItemMatchProps): JSX.Element {
+  const isLimited = isLimitedEventId(row.event_id);
+  const won = row.player_wins > row.player_losses;
+
+  // Draft decks carry the stock tile; borrow the deck's first mythic — or
+  // failing that, first rare — for art, exactly like the History tab.
+  const rawTileId = row.deck_tile_id ?? 0;
+  const deckTileId = rawTileId === DEFAULT_TILE ? 0 : rawTileId;
+  const fallbackIds = useMemo(
+    () => (deckTileId ? [] : _.uniq(row.fallback_ids ?? [])),
+    [deckTileId, row.fallback_ids]
+  );
+  const fallbackCards = useCards(fallbackIds);
+  const fallbackTile = useMemo(() => {
+    const mythic = fallbackCards.find((c) => c?.Rarity === "mythic");
+    const rare = fallbackCards.find((c) => c?.Rarity === "rare");
+    return (mythic ?? rare)?.GrpId;
+  }, [fallbackCards]);
+
+  return (
+    <ListItem click={(): void => openMatchCallback(row)}>
+      <div
+        className="list-item-left-indicator"
+        style={{
+          backgroundColor: won ? `var(--color-g)` : `var(--color-r)`,
+        }}
+      />
+      <HoverTile grpId={deckTileId || fallbackTile || DEFAULT_TILE}>
+        {row.player_rank?.rank ? (
+          <RankIcon
+            rank={row.player_rank.rank}
+            tier={row.player_rank.tier ?? 0}
+            percentile={row.player_rank.percentile || 0}
+            leaderboardPlace={row.player_rank.leaderboardPlace || 0}
+            format={isLimited ? "limited" : "constructed"}
+          />
+        ) : null}
+      </HoverTile>
+
+      <Column className="list-item-left">
+        <FlexTop>
+          <div className="list-deck-name">{row.deck_name || ""}</div>
+          <div className="list-deck-name-it">
+            {getEventPrettyName(row.event_id)}
+          </div>
+        </FlexTop>
+        <FlexBottom>
+          <ManaCost
+            className="mana-s20"
+            colors={new Colors().addFromBits(row.player_deck_colors || 0).get()}
+          />
+          <div
+            style={{
+              lineHeight: "30px",
+              marginLeft: "4px",
+              marginRight: "auto",
+            }}
+            className="list-match-time"
+          >
+            <div className="time">
+              {timeAgo(new Date(row.played_at).getTime())}
+            </div>{" "}
+            {`${toMMSS(row.duration || 0)} long`}
+          </div>
+        </FlexBottom>
+      </Column>
+
+      <Column className="list-item-center">
+        <></>
+      </Column>
+
+      <Column className="list-item-right">
+        <FlexTop>
+          <div className="list-match-title">
+            {`vs ${
+              row.opp_name
+                ? getPlayerNameWithoutSuffix(row.opp_name)
+                : "Opponent"
+            }`}
+          </div>
+          <RankSmall
+            rank={{
+              rank: row.opp_rank?.rank || "Unranked",
+              tier: row.opp_rank?.tier ?? 0,
+              step: row.opp_rank?.step || 0,
+              won: 0,
+              lost: 0,
+              drawn: 0,
+              seasonOrdinal: 0,
+              percentile: row.opp_rank?.percentile || 0,
+              leaderboardPlace: row.opp_rank?.leaderboardPlace || 0,
+            }}
+          />
+        </FlexTop>
+        <FlexBottom
+          style={{
+            alignItems: "center",
+            justifyContent: "flex-end",
+          }}
+        >
+          <ManaCost
+            className="mana-s20"
+            colors={new Colors().addFromBits(row.opp_deck_colors || 0).get()}
+          />
+        </FlexBottom>
+      </Column>
+
+      <Column className="list-match-result">
+        <div className={won ? "green" : "red"}>
+          {row.player_wins}:{row.player_losses}
+        </div>
+      </Column>
+    </ListItem>
+  );
+}

--- a/src/components/views/profile/ProfileListItemMatch.tsx
+++ b/src/components/views/profile/ProfileListItemMatch.tsx
@@ -35,7 +35,7 @@ export default function ProfileListItemMatch({
   row,
   openMatchCallback,
 }: ProfileListItemMatchProps): JSX.Element {
-  const isLimited = isLimitedEventId(row.event_id);
+  const isLimited = isLimitedEventId(row.event_id || "");
   const won = row.player_wins > row.player_losses;
 
   // Draft decks carry the stock tile; borrow the deck's first mythic — or
@@ -77,7 +77,7 @@ export default function ProfileListItemMatch({
         <FlexTop>
           <div className="list-deck-name">{row.deck_name || ""}</div>
           <div className="list-deck-name-it">
-            {getEventPrettyName(row.event_id)}
+            {getEventPrettyName(row.event_id || "")}
           </div>
         </FlexTop>
         <FlexBottom>
@@ -94,7 +94,9 @@ export default function ProfileListItemMatch({
             className="list-match-time"
           >
             <div className="time">
-              {timeAgo(new Date(row.played_at).getTime())}
+              {row.played_at
+                ? timeAgo(new Date(row.played_at).getTime())
+                : "\u2014"}
             </div>{" "}
             {`${toMMSS(row.duration || 0)} long`}
           </div>

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_TILE } from "../../../constants";
 import { getPlayerDecks, PlayerDeckRow } from "../../../data/publicProfiles";
 import { useCards } from "../../../hooks/useCard";
 import { useCardArtCrop } from "../../../hooks/useCardImage";
+import useIsLoggedIn from "../../../hooks/useIsLoggedIn";
 import Deck from "../../../utils/mtga/deck";
 import timeAgo from "../../../utils/timeAgo";
 import DeckColorsBar from "../../DeckColorsBar";
@@ -31,6 +32,7 @@ export default function PublicDeckView({
   deckId,
 }: PublicDeckViewProps): JSX.Element {
   const history = useHistory();
+  const loggedIn = useIsLoggedIn();
 
   const [row, setRow] = useState<PlayerDeckRow | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -125,7 +127,7 @@ export default function PublicDeckView({
         <>
           <PublicDeckDetails
             deck={deck}
-            showWildcards
+            showWildcards={loggedIn}
             recordSlot={
               games > 0 ? (
                 <div

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -43,9 +43,7 @@ export default function PublicDeckView({
     setRow(null);
     setLoaded(false);
     getPlayerDecks({ arenaId: profileId })
-      .then((p) =>
-        p?.decks.length ? p : getPlayerDecks({ username: profileId })
-      )
+      .then((p) => p ?? getPlayerDecks({ username: profileId }))
       .then((p) => {
         if (cancelled) return;
         setRow(p?.decks.find((d) => d.id === deckId) ?? null);

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -1,35 +1,30 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { ReactComponent as BackIcon } from "../../../assets/images/svg/back.svg";
-import {
-  getPlayerDecks,
-  getPlayerMatches,
-  PlayerDeckRow,
-  PlayerMatchesPage,
-  PlayerMatchRow,
-} from "../../../data/publicProfiles";
+import { DEFAULT_TILE } from "../../../constants";
+import { getPlayerDecks, PlayerDeckRow } from "../../../data/publicProfiles";
+import { useCards } from "../../../hooks/useCard";
 import { useCardArtCrop } from "../../../hooks/useCardImage";
-import formatPercent from "../../../utils/formatPercent";
-import getWinrateClass from "../../../utils/getWinrateClass";
-import Colors from "../../../utils/mtga/colors";
+import Deck from "../../../utils/mtga/deck";
 import timeAgo from "../../../utils/timeAgo";
+import DeckColorsBar from "../../DeckColorsBar";
 import ManaCost from "../../ManaCost";
+import PublicDeckDetails from "../../PublicDeckDetails";
 import SvgButton from "../../SvgButton";
 import Section from "../../ui/Section";
-import ProfileListItemMatch from "./ProfileListItemMatch";
+import PlayerMatchesSection from "./PlayerMatchesSection";
 
 interface PublicDeckViewProps {
   profileId: string;
   deckId: string;
 }
 
-const PAGE_SIZE = 25;
-
 /**
- * One of a profile's decks: its record and the matches played with it.
- * Reached from the profile's deck list, which is patron-gated — so is the
- * match lookup underneath this view.
+ * One of a profile's decks: the same presentation as the shared-deck page
+ * (list, charts, visual view) plus its aggregate record and the matches
+ * played with it. Reached from the profile's deck list, which is
+ * patron-gated — so is the match lookup underneath this view.
  */
 export default function PublicDeckView({
   profileId,
@@ -37,85 +32,53 @@ export default function PublicDeckView({
 }: PublicDeckViewProps): JSX.Element {
   const history = useHistory();
 
-  const [deck, setDeck] = useState<PlayerDeckRow | null>(null);
-  const [page, setPage] = useState<PlayerMatchesPage | null>(null);
-  const [loadingMore, setLoadingMore] = useState(false);
+  const [row, setRow] = useState<PlayerDeckRow | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    setDeck(null);
-    setPage(null);
+    setRow(null);
+    setLoaded(false);
     getPlayerDecks({ arenaId: profileId })
       .then((p) =>
         p?.decks.length ? p : getPlayerDecks({ username: profileId })
       )
       .then((p) => {
         if (cancelled) return;
-        setDeck(p?.decks.find((d) => d.id === deckId) ?? null);
-      });
-    getPlayerMatches({ arenaId: profileId }, PAGE_SIZE, 0, deckId)
-      .then(
-        (p) =>
-          p ?? getPlayerMatches({ username: profileId }, PAGE_SIZE, 0, deckId)
-      )
-      .then((p) => {
-        if (!cancelled && p) setPage(p);
+        setRow(p?.decks.find((d) => d.id === deckId) ?? null);
+        setLoaded(true);
       });
     return () => {
       cancelled = true;
     };
   }, [profileId, deckId]);
 
-  const loadMore = useCallback(() => {
-    if (!page || loadingMore) return;
-    setLoadingMore(true);
-    getPlayerMatches(
-      { arenaId: profileId },
-      PAGE_SIZE,
-      page.matches.length,
-      deckId
-    )
-      .then(
-        (p) =>
-          p ??
-          getPlayerMatches(
-            { username: profileId },
-            PAGE_SIZE,
-            page.matches.length,
-            deckId
-          )
-      )
-      .then((p) => {
-        setLoadingMore(false);
-        if (p && p.matches.length > 0) {
-          setPage({ ...p, matches: [...page.matches, ...p.matches] });
-        }
-      });
-  }, [profileId, deckId, page, loadingMore]);
+  const snapshot = row?.deck;
 
-  const openMatch = useCallback(
-    (row: PlayerMatchRow) => {
-      history.push(
-        `/profile/${encodeURIComponent(profileId)}/match/${encodeURIComponent(
-          row.match_id
-        )}`
-      );
-    },
-    [history, profileId]
-  );
+  // The list and charts read cards synchronously from the lookup cache,
+  // which is empty on a cold public page. Prefetch and rebuild once they
+  // land (same fix as the shared-deck page).
+  const allIds = useMemo(() => {
+    const ids = new Set<number>();
+    (snapshot?.mainDeck || []).forEach((c) => ids.add(c.id));
+    (snapshot?.sideboard || []).forEach((c) => ids.add(c.id));
+    return [...ids];
+  }, [snapshot]);
+  const resolvedCards = useCards(allIds);
 
-  const deckArt = useCardArtCrop(deck?.deck?.deckTileId || 0);
+  const deck = useMemo(() => {
+    const d = new Deck({}, snapshot?.mainDeck || [], snapshot?.sideboard || []);
+    d.setName(snapshot?.name || "Deck");
+    d.tile = snapshot?.deckTileId || DEFAULT_TILE;
+    return d;
+    // resolvedCards is the point: the charts read from the card cache,
+    // which is only warm once these lookups come back.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshot, resolvedCards]);
 
-  const colors = useMemo(
-    () => new Colors().addFromBits(deck?.deck?.colors || 0).get(),
-    [deck]
-  );
+  const deckArt = useCardArtCrop(snapshot?.deckTileId || DEFAULT_TILE);
 
-  const wins = deck?.wins ?? 0;
-  const games = deck?.games ?? 0;
-  const winrate = games > 0 ? wins / games : 0;
-
-  if (!page && !deck) {
+  if (!loaded) {
     return (
       <div className="profile-view">
         <Section style={{ marginTop: "16px", padding: "48px" }}>
@@ -125,14 +88,13 @@ export default function PublicDeckView({
     );
   }
 
+  const wins = row?.wins ?? 0;
+  const games = row?.games ?? 0;
+
   return (
     <div className="profile-view">
-      <div
-        className="matches-top"
-        style={{
-          backgroundImage: deckArt ? `url("${deckArt}")` : undefined,
-        }}
-      >
+      <div className="decks-top" style={{ backgroundImage: `url(${deckArt})` }}>
+        <DeckColorsBar deck={deck} />
         <div className="top-inner">
           <div className="flex-item">
             <SvgButton
@@ -150,67 +112,65 @@ export default function PublicDeckView({
                 textShadow: "3px 3px 6px #000000",
               }}
             >
-              {deck?.deck?.name || "Deck"}
+              {deck.getName()}
             </div>
           </div>
           <div className="flex-item">
-            <ManaCost className="manaS20" colors={colors} />
+            <ManaCost className="mana-s20" colors={deck.getColors().get()} />
           </div>
         </div>
       </div>
 
-      {deck ? (
+      {row ? (
+        <>
+          <PublicDeckDetails
+            deck={deck}
+            showWildcards
+            recordSlot={
+              games > 0 ? (
+                <div
+                  className="shared-deck-record"
+                  title={`Last played ${timeAgo(
+                    new Date(row.last_played).getTime()
+                  )}`}
+                >
+                  <span className="record">{`${wins}-${games - wins}`}</span>
+                  <span
+                    className="percent"
+                    style={{
+                      color:
+                        wins / games >= 0.5
+                          ? "var(--color-g)"
+                          : "var(--color-r)",
+                    }}
+                  >
+                    {`${((wins / games) * 100).toFixed(0)}%`}
+                  </span>
+                  <span className="record-label">win rate</span>
+                </div>
+              ) : undefined
+            }
+          />
+          <PlayerMatchesSection
+            id={profileId}
+            deckId={deckId}
+            title="Matches with this deck"
+          />
+        </>
+      ) : (
         <Section
           style={{
-            lineHeight: "36px",
-            padding: "16px",
-            margin: "16px 0 0",
-            justifyContent: "space-around",
+            marginTop: "16px",
+            padding: "48px",
+            flexDirection: "column",
+            textAlign: "center",
           }}
         >
-          <div>
-            Record:{" "}
-            <span style={{ color: "var(--color-text-hover)" }}>
-              {wins}-{games - wins}
-            </span>
-          </div>
-          <div>
-            Winrate:{" "}
-            <span className={getWinrateClass(winrate, true)}>
-              {formatPercent(winrate)}
-            </span>
-          </div>
-          <div>
-            Last played:{" "}
-            <span style={{ color: "var(--color-text-hover)" }}>
-              {timeAgo(new Date(deck.last_played).getTime())}
-            </span>
+          <div style={{ color: "var(--color-text-dark)" }}>
+            This deck is not available.
           </div>
         </Section>
-      ) : null}
-
-      <Section
-        style={{ flexDirection: "column", padding: "16px", margin: "16px 0" }}
-      >
-        <div className="profile-section-title">Matches with this deck</div>
-        {(page?.matches ?? []).map((row) => (
-          <ProfileListItemMatch
-            row={row}
-            key={`deck-match-${row.match_id}`}
-            openMatchCallback={openMatch}
-          />
-        ))}
-        {page && page.matches.length < page.total ? (
-          <div
-            className="profile-matches-more"
-            onClick={loadingMore ? undefined : loadMore}
-          >
-            {loadingMore
-              ? "Loading..."
-              : `Show more (${page.matches.length} of ${page.total})`}
-          </div>
-        ) : null}
-      </Section>
+      )}
     </div>
   );
 }

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -12,6 +12,7 @@ import timeAgo from "../../../utils/timeAgo";
 import DeckColorsBar from "../../DeckColorsBar";
 import ManaCost from "../../ManaCost";
 import PublicDeckDetails from "../../PublicDeckDetails";
+import PublicLoading from "../../PublicLoading";
 import SvgButton from "../../SvgButton";
 import Section from "../../ui/Section";
 import PlayerMatchesSection from "./PlayerMatchesSection";
@@ -84,7 +85,7 @@ export default function PublicDeckView({
     return (
       <div className="profile-view">
         <Section style={{ marginTop: "16px", padding: "48px" }}>
-          <div className="loading-sign" style={{ margin: "auto" }} />
+          <PublicLoading inline />
         </Section>
       </div>
     );

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useHistory } from "react-router-dom";
+
+import { ReactComponent as BackIcon } from "../../../assets/images/svg/back.svg";
+import {
+  getPlayerDecks,
+  getPlayerMatches,
+  PlayerDeckRow,
+  PlayerMatchesPage,
+  PlayerMatchRow,
+} from "../../../data/publicProfiles";
+import { useCardArtCrop } from "../../../hooks/useCardImage";
+import formatPercent from "../../../utils/formatPercent";
+import getWinrateClass from "../../../utils/getWinrateClass";
+import Colors from "../../../utils/mtga/colors";
+import timeAgo from "../../../utils/timeAgo";
+import ManaCost from "../../ManaCost";
+import SvgButton from "../../SvgButton";
+import Section from "../../ui/Section";
+import ProfileListItemMatch from "./ProfileListItemMatch";
+
+interface PublicDeckViewProps {
+  profileId: string;
+  deckId: string;
+}
+
+const PAGE_SIZE = 25;
+
+/**
+ * One of a profile's decks: its record and the matches played with it.
+ * Reached from the profile's deck list, which is patron-gated — so is the
+ * match lookup underneath this view.
+ */
+export default function PublicDeckView({
+  profileId,
+  deckId,
+}: PublicDeckViewProps): JSX.Element {
+  const history = useHistory();
+
+  const [deck, setDeck] = useState<PlayerDeckRow | null>(null);
+  const [page, setPage] = useState<PlayerMatchesPage | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDeck(null);
+    setPage(null);
+    getPlayerDecks({ arenaId: profileId })
+      .then((p) =>
+        p?.decks.length ? p : getPlayerDecks({ username: profileId })
+      )
+      .then((p) => {
+        if (cancelled) return;
+        setDeck(p?.decks.find((d) => d.id === deckId) ?? null);
+      });
+    getPlayerMatches({ arenaId: profileId }, PAGE_SIZE, 0, deckId)
+      .then(
+        (p) =>
+          p ?? getPlayerMatches({ username: profileId }, PAGE_SIZE, 0, deckId)
+      )
+      .then((p) => {
+        if (!cancelled && p) setPage(p);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId, deckId]);
+
+  const loadMore = useCallback(() => {
+    if (!page || loadingMore) return;
+    setLoadingMore(true);
+    getPlayerMatches(
+      { arenaId: profileId },
+      PAGE_SIZE,
+      page.matches.length,
+      deckId
+    )
+      .then(
+        (p) =>
+          p ??
+          getPlayerMatches(
+            { username: profileId },
+            PAGE_SIZE,
+            page.matches.length,
+            deckId
+          )
+      )
+      .then((p) => {
+        setLoadingMore(false);
+        if (p && p.matches.length > 0) {
+          setPage({ ...p, matches: [...page.matches, ...p.matches] });
+        }
+      });
+  }, [profileId, deckId, page, loadingMore]);
+
+  const openMatch = useCallback(
+    (row: PlayerMatchRow) => {
+      history.push(
+        `/profile/${encodeURIComponent(profileId)}/match/${encodeURIComponent(
+          row.match_id
+        )}`
+      );
+    },
+    [history, profileId]
+  );
+
+  const deckArt = useCardArtCrop(deck?.deck?.deckTileId || 0);
+
+  const colors = useMemo(
+    () => new Colors().addFromBits(deck?.deck?.colors || 0).get(),
+    [deck]
+  );
+
+  const wins = deck?.wins ?? 0;
+  const games = deck?.games ?? 0;
+  const winrate = games > 0 ? wins / games : 0;
+
+  if (!page && !deck) {
+    return (
+      <div className="profile-view">
+        <Section style={{ marginTop: "16px", padding: "48px" }}>
+          <div className="loading-sign" style={{ margin: "auto" }} />
+        </Section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="profile-view">
+      <div
+        className="matches-top"
+        style={{
+          backgroundImage: deckArt ? `url("${deckArt}")` : undefined,
+        }}
+      >
+        <div className="top-inner">
+          <div className="flex-item">
+            <SvgButton
+              style={{
+                marginRight: "8px",
+                backgroundColor: "var(--color-section)",
+              }}
+              svg={BackIcon}
+              onClick={(): void => history.goBack()}
+            />
+            <div
+              style={{
+                lineHeight: "32px",
+                color: "var(--color-text-hover)",
+                textShadow: "3px 3px 6px #000000",
+              }}
+            >
+              {deck?.deck?.name || "Deck"}
+            </div>
+          </div>
+          <div className="flex-item">
+            <ManaCost className="manaS20" colors={colors} />
+          </div>
+        </div>
+      </div>
+
+      {deck ? (
+        <Section
+          style={{
+            lineHeight: "36px",
+            padding: "16px",
+            margin: "16px 0 0",
+            justifyContent: "space-around",
+          }}
+        >
+          <div>
+            Record:{" "}
+            <span style={{ color: "var(--color-text-hover)" }}>
+              {wins}-{games - wins}
+            </span>
+          </div>
+          <div>
+            Winrate:{" "}
+            <span className={getWinrateClass(winrate, true)}>
+              {formatPercent(winrate)}
+            </span>
+          </div>
+          <div>
+            Last played:{" "}
+            <span style={{ color: "var(--color-text-hover)" }}>
+              {timeAgo(new Date(deck.last_played).getTime())}
+            </span>
+          </div>
+        </Section>
+      ) : null}
+
+      <Section
+        style={{ flexDirection: "column", padding: "16px", margin: "16px 0" }}
+      >
+        <div className="profile-section-title">Matches with this deck</div>
+        {(page?.matches ?? []).map((row) => (
+          <ProfileListItemMatch
+            row={row}
+            key={`deck-match-${row.match_id}`}
+            openMatchCallback={openMatch}
+          />
+        ))}
+        {page && page.matches.length < page.total ? (
+          <div
+            className="profile-matches-more"
+            onClick={loadingMore ? undefined : loadMore}
+          >
+            {loadingMore
+              ? "Loading..."
+              : `Show more (${page.matches.length} of ${page.total})`}
+          </div>
+        ) : null}
+      </Section>
+    </div>
+  );
+}

--- a/src/components/views/profile/PublicDeckView.tsx
+++ b/src/components/views/profile/PublicDeckView.tsx
@@ -131,9 +131,13 @@ export default function PublicDeckView({
               games > 0 ? (
                 <div
                   className="shared-deck-record"
-                  title={`Last played ${timeAgo(
-                    new Date(row.last_played).getTime()
-                  )}`}
+                  title={
+                    row.last_played
+                      ? `Last played ${timeAgo(
+                          new Date(row.last_played).getTime()
+                        )}`
+                      : undefined
+                  }
                 >
                   <span className="record">{`${wins}-${games - wins}`}</span>
                   <span

--- a/src/components/views/profile/PublicMatchView.tsx
+++ b/src/components/views/profile/PublicMatchView.tsx
@@ -147,7 +147,7 @@ export default function PublicMatchView({
     );
   }
 
-  const isLimited = isLimitedEventId(match.event_id);
+  const isLimited = isLimitedEventId(match.event_id || "");
   const won = match.player_wins > match.player_losses;
 
   return (
@@ -210,7 +210,7 @@ export default function PublicMatchView({
             style={{ margin: "auto 16px auto 8px" }}
             fill="var(--color-icon)"
           />
-          <div>{getEventPrettyName(match.event_id)}</div>
+          <div>{getEventPrettyName(match.event_id || "")}</div>
         </Flex>
         <Flex>
           <IconTime

--- a/src/components/views/profile/PublicMatchView.tsx
+++ b/src/components/views/profile/PublicMatchView.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+
+import { ReactComponent as BackIcon } from "../../../assets/images/svg/back.svg";
+import { ReactComponent as IconCrown } from "../../../assets/images/svg/crown.svg";
+import { ReactComponent as IconEvent } from "../../../assets/images/svg/event.svg";
+import { ReactComponent as IconTime } from "../../../assets/images/svg/time.svg";
+import { getPublicMatch, PublicMatch } from "../../../data/publicProfiles";
+import { useCards } from "../../../hooks/useCard";
+import { useCardArtCrop } from "../../../hooks/useCardImage";
+import reduxAction from "../../../redux/reduxAction";
+import compareCards from "../../../utils/compareCards";
+import copyToClipboard from "../../../utils/copyToClipboard";
+import { toMMSS } from "../../../utils/dateTo";
+import getEventPrettyName from "../../../utils/getEventPrettyName";
+import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
+import isLimitedEventId from "../../../utils/isLimitedEventId";
+import Colors from "../../../utils/mtga/colors";
+import Deck from "../../../utils/mtga/deck";
+import ActionLogV2 from "../../action-log-v2";
+import { ActionLogV2 as ActionLogV2Type } from "../../action-log-v2/types";
+import ActionLog from "../../ActionLog";
+import DeckColorsBar from "../../DeckColorsBar";
+import DeckList from "../../DeckList";
+import Flex from "../../Flex";
+import ManaCost from "../../ManaCost";
+import RankIcon from "../../RankIcon";
+import SvgButton from "../../SvgButton";
+import Button from "../../ui/Button";
+import Section from "../../ui/Section";
+
+interface PublicMatchViewProps {
+  profileId: string;
+  matchId: string;
+}
+
+/**
+ * The public view of one match, opened from a profile's match list. Shows
+ * the deck the player ran, the result, event and both ranks — mirroring the
+ * private match view's layout without its private parts (opponent name,
+ * action log, per-game telemetry).
+ */
+export default function PublicMatchView({
+  profileId,
+  matchId,
+}: PublicMatchViewProps): JSX.Element {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const [match, setMatch] = useState<PublicMatch | null>(null);
+  const [missing, setMissing] = useState(false);
+
+  useEffect(() => {
+    setMatch(null);
+    setMissing(false);
+    let cancelled = false;
+    // Same two-step resolution as the profile: the id is usually an arena
+    // persona id, but /profile/<username> links exist too.
+    getPublicMatch(matchId, { arenaId: profileId })
+      .then((m) => m ?? getPublicMatch(matchId, { username: profileId }))
+      .then((m) => {
+        if (cancelled) return;
+        if (m) setMatch(m);
+        else setMissing(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId, matchId]);
+
+  const snapshot = match?.player_deck;
+
+  // Prefetch the whole list so DeckList and the charts do not render blank
+  // on a cold public page (same fix as the shared-deck view).
+  const allIds = useMemo(() => {
+    const ids = new Set<number>();
+    (snapshot?.mainDeck || []).forEach((c) => ids.add(c.id));
+    (snapshot?.sideboard || []).forEach((c) => ids.add(c.id));
+    return [...ids];
+  }, [snapshot]);
+  const resolvedCards = useCards(allIds);
+
+  const deck = useMemo(() => {
+    const d = new Deck({}, snapshot?.mainDeck || [], snapshot?.sideboard || []);
+    d.setName(snapshot?.name || "Deck");
+    d.tile = snapshot?.deckTileId || 0;
+    return d;
+    // resolvedCards is the point: DeckList reads from the card cache, which
+    // is only warm once these lookups come back.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshot, resolvedCards]);
+
+  const deckArt = useCardArtCrop(snapshot?.deckTileId || 0);
+
+  const arenaExport = (): void => {
+    // A fresh Deck: sorting in place would reorder the memoized one the
+    // page is rendering.
+    const exportDeck = new Deck(
+      {},
+      snapshot?.mainDeck || [],
+      snapshot?.sideboard || []
+    );
+    exportDeck.sortMainboard(compareCards);
+    exportDeck.sortSideboard(compareCards);
+    copyToClipboard(exportDeck.getExportArena());
+    reduxAction(dispatch, {
+      type: "SET_POPUP",
+      arg: {
+        text: "Deck copied to clipboard.",
+        duration: 5000,
+        time: new Date().getTime(),
+      },
+    });
+  };
+
+  if (missing) {
+    return (
+      <div className="profile-view">
+        <Section
+          style={{
+            marginTop: "16px",
+            padding: "48px",
+            flexDirection: "column",
+            textAlign: "center",
+          }}
+        >
+          <div style={{ color: "var(--color-text-dark)" }}>
+            This match is not available.
+          </div>
+        </Section>
+      </div>
+    );
+  }
+
+  if (!match) {
+    return (
+      <div className="profile-view">
+        <Section style={{ marginTop: "16px", padding: "48px" }}>
+          <div className="loading-sign" style={{ margin: "auto" }} />
+        </Section>
+      </div>
+    );
+  }
+
+  const isLimited = isLimitedEventId(match.event_id);
+  const won = match.player_wins > match.player_losses;
+
+  return (
+    <div className="profile-view">
+      <div
+        className="matches-top"
+        style={{
+          backgroundImage: deckArt ? `url("${deckArt}")` : undefined,
+        }}
+      >
+        <DeckColorsBar deck={deck} />
+        <div className="top-inner">
+          <div className="flex-item">
+            <SvgButton
+              style={{
+                marginRight: "8px",
+                backgroundColor: "var(--color-section)",
+              }}
+              svg={BackIcon}
+              onClick={(): void => history.goBack()}
+            />
+            <div
+              style={{
+                lineHeight: "32px",
+                color: "var(--color-text-hover)",
+                textShadow: "3px 3px 6px #000000",
+              }}
+            >
+              {deck.getName()}
+            </div>
+          </div>
+          <div className="flex-item">
+            <ManaCost className="manaS20" colors={deck.getColors().get()} />
+          </div>
+        </div>
+      </div>
+
+      <Section
+        style={{
+          lineHeight: "36px",
+          padding: "16px",
+          margin: "16px 0 0",
+          justifyContent: "space-between",
+        }}
+      >
+        <Flex>
+          <IconCrown
+            style={{ margin: "auto 16px auto 8px" }}
+            fill="var(--color-icon)"
+          />
+          <div
+            className="match-top-result"
+            style={{ color: `var(--color-${won ? "g" : "r"})` }}
+          >
+            {`${match.player_wins}-${match.player_losses}`}
+          </div>
+        </Flex>
+        <Flex>
+          <IconEvent
+            style={{ margin: "auto 16px auto 8px" }}
+            fill="var(--color-icon)"
+          />
+          <div>{getEventPrettyName(match.event_id)}</div>
+        </Flex>
+        <Flex>
+          <IconTime
+            style={{ margin: "auto 16px auto 8px" }}
+            fill="var(--color-icon)"
+          />
+          <div>{toMMSS(match.duration || 0)}</div>
+        </Flex>
+        <Button
+          style={{ width: "auto", padding: "0 10px" }}
+          onClick={arenaExport}
+          text="Export to Arena"
+        />
+      </Section>
+
+      <Section
+        style={{
+          padding: "16px",
+          margin: "16px 0 0",
+          maxHeight: "48px",
+          justifyContent: "space-between",
+        }}
+      >
+        <div className="match-player-name">
+          {`vs ${
+            match.opp_name
+              ? getPlayerNameWithoutSuffix(match.opp_name)
+              : "Opponent"
+          }`}
+        </div>
+        {match.opp_rank?.rank ? (
+          <RankIcon
+            rank={match.opp_rank.rank}
+            tier={match.opp_rank.tier ?? 0}
+            percentile={match.opp_rank.percentile || 0}
+            leaderboardPlace={match.opp_rank.leaderboardPlace || 0}
+            format={isLimited ? "limited" : "constructed"}
+          />
+        ) : null}
+        <Flex>
+          <ManaCost
+            colors={new Colors().addFromBits(match.opp_deck_colors || 0).get()}
+          />
+        </Flex>
+      </Section>
+
+      <div className={`public-match-grid${match.action_log ? "" : " no-log"}`}>
+        <Section
+          style={{
+            padding: "16px",
+            flexDirection: "column",
+          }}
+        >
+          <DeckList deck={deck} showWildcards={false} />
+        </Section>
+        {match.action_log ? (
+          <Section
+            style={{
+              padding: "16px",
+              flexDirection: "column",
+            }}
+          >
+            {typeof match.action_log === "string" ? (
+              <ActionLog logStr={match.action_log} />
+            ) : (
+              <ActionLogV2
+                actionLog={match.action_log as unknown as ActionLogV2Type}
+              />
+            )}
+          </Section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/views/profile/PublicMatchView.tsx
+++ b/src/components/views/profile/PublicMatchView.tsx
@@ -260,7 +260,7 @@ export default function PublicMatchView({
             flexDirection: "column",
           }}
         >
-          <DeckList deck={deck} showWildcards={false} />
+          <DeckList deck={deck} showWildcards />
         </Section>
         {match.action_log ? (
           <Section

--- a/src/components/views/profile/PublicMatchView.tsx
+++ b/src/components/views/profile/PublicMatchView.tsx
@@ -27,6 +27,7 @@ import DeckList from "../../DeckList";
 import Flex from "../../Flex";
 import LoginPrompt from "../../LoginPrompt";
 import ManaCost from "../../ManaCost";
+import PublicLoading from "../../PublicLoading";
 import RankIcon from "../../RankIcon";
 import SvgButton from "../../SvgButton";
 import Button from "../../ui/Button";
@@ -140,7 +141,7 @@ export default function PublicMatchView({
     return (
       <div className="profile-view">
         <Section style={{ marginTop: "16px", padding: "48px" }}>
-          <div className="loading-sign" style={{ margin: "auto" }} />
+          <PublicLoading inline />
         </Section>
       </div>
     );

--- a/src/components/views/profile/PublicMatchView.tsx
+++ b/src/components/views/profile/PublicMatchView.tsx
@@ -9,6 +9,7 @@ import { ReactComponent as IconTime } from "../../../assets/images/svg/time.svg"
 import { getPublicMatch, PublicMatch } from "../../../data/publicProfiles";
 import { useCards } from "../../../hooks/useCard";
 import { useCardArtCrop } from "../../../hooks/useCardImage";
+import useIsLoggedIn from "../../../hooks/useIsLoggedIn";
 import reduxAction from "../../../redux/reduxAction";
 import compareCards from "../../../utils/compareCards";
 import copyToClipboard from "../../../utils/copyToClipboard";
@@ -24,6 +25,7 @@ import ActionLog from "../../ActionLog";
 import DeckColorsBar from "../../DeckColorsBar";
 import DeckList from "../../DeckList";
 import Flex from "../../Flex";
+import LoginPrompt from "../../LoginPrompt";
 import ManaCost from "../../ManaCost";
 import RankIcon from "../../RankIcon";
 import SvgButton from "../../SvgButton";
@@ -47,6 +49,7 @@ export default function PublicMatchView({
 }: PublicMatchViewProps): JSX.Element {
   const history = useHistory();
   const dispatch = useDispatch();
+  const loggedIn = useIsLoggedIn();
 
   const [match, setMatch] = useState<PublicMatch | null>(null);
   const [missing, setMissing] = useState(false);
@@ -253,6 +256,8 @@ export default function PublicMatchView({
         </Flex>
       </Section>
 
+      <LoginPrompt />
+
       <div className={`public-match-grid${match.action_log ? "" : " no-log"}`}>
         <Section
           style={{
@@ -260,7 +265,7 @@ export default function PublicMatchView({
             flexDirection: "column",
           }}
         >
-          <DeckList deck={deck} showWildcards />
+          <DeckList deck={deck} showWildcards={loggedIn} />
         </Section>
         {match.action_log ? (
           <Section

--- a/src/components/views/profile/PublicProfilePage.tsx
+++ b/src/components/views/profile/PublicProfilePage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import logoBig from "../../../assets/images/logo_big.png";
+import cardsDb from "../../../utils/cardsDb/cardsDbClient";
+import ViewProfile from "./ViewProfile";
+
+/**
+ * Standalone shell for /profile/<id> when nobody is signed in — a shared
+ * profile link must work like a shared deck link does. Everything the
+ * profile shows comes from anon-callable RPCs; the shell only has to load
+ * the cards database (normally done by the login flow) and provide a
+ * scrollable page for the same ViewProfile the app renders.
+ */
+export default function PublicProfilePage(): JSX.Element {
+  const [dbReady, setDbReady] = useState(false);
+  const [dbFailed, setDbFailed] = useState(false);
+
+  useEffect(() => {
+    cardsDb
+      .init()
+      .then((ready) => (ready ? setDbReady(true) : setDbFailed(true)))
+      .catch(() => setDbFailed(true));
+  }, []);
+
+  if (dbFailed) {
+    return (
+      <div className="shared-deck-missing">
+        <img src={logoBig} alt="MTG Arena Tool" />
+        <div>Could not load the card database — try reloading the page.</div>
+      </div>
+    );
+  }
+
+  if (!dbReady) {
+    return <div className="shared-deck-missing">Loading profile…</div>;
+  }
+
+  return (
+    <div className="public-profile-page">
+      <ViewProfile />
+    </div>
+  );
+}

--- a/src/components/views/profile/PublicProfilePage.tsx
+++ b/src/components/views/profile/PublicProfilePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import logoBig from "../../../assets/images/logo_big.png";
 import cardsDb from "../../../utils/cardsDb/cardsDbClient";
+import PublicLoading from "../../PublicLoading";
 import PublicTopBar from "../../PublicTopBar";
 import ViewProfile from "./ViewProfile";
 
@@ -33,7 +34,7 @@ export default function PublicProfilePage(): JSX.Element {
   }
 
   if (!dbReady) {
-    return <div className="shared-deck-missing">Loading profile…</div>;
+    return <PublicLoading label="Loading profile…" />;
   }
 
   return (

--- a/src/components/views/profile/PublicProfilePage.tsx
+++ b/src/components/views/profile/PublicProfilePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import logoBig from "../../../assets/images/logo_big.png";
 import cardsDb from "../../../utils/cardsDb/cardsDbClient";
+import PublicTopBar from "../../PublicTopBar";
 import ViewProfile from "./ViewProfile";
 
 /**
@@ -37,6 +38,7 @@ export default function PublicProfilePage(): JSX.Element {
 
   return (
     <div className="public-profile-page">
+      <PublicTopBar />
       <ViewProfile />
     </div>
   );

--- a/src/components/views/profile/ViewProfile.tsx
+++ b/src/components/views/profile/ViewProfile.tsx
@@ -18,6 +18,7 @@ import getEventFormat from "../../../utils/getEventFormat";
 import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
 import timeAgo from "../../../utils/timeAgo";
 import PatreonInfo from "../../popups/PatreonInfo";
+import PublicLoading from "../../PublicLoading";
 import RankIcon from "../../RankIcon";
 import SupporterBadge from "../../SupporterBadge";
 import Button from "../../ui/Button";
@@ -252,7 +253,7 @@ function ProfileContent({ id }: { id: string }): JSX.Element {
         </Section>
       ) : !profile ? (
         <Section style={{ marginTop: "16px", padding: "48px" }}>
-          <div className="loading-sign" style={{ margin: "auto" }} />
+          <PublicLoading inline />
         </Section>
       ) : (
         <>

--- a/src/components/views/profile/ViewProfile.tsx
+++ b/src/components/views/profile/ViewProfile.tsx
@@ -4,12 +4,9 @@ import { useHistory, useRouteMatch } from "react-router-dom";
 import { DEFAULT_AVATAR } from "../../../constants";
 import {
   getPlayerDecks,
-  getPlayerMatches,
   getPlayerProfile,
   PlayerDeckRow,
   PlayerDecksPage,
-  PlayerMatchesPage,
-  PlayerMatchRow,
   PlayerProfile,
   ProfileAccount,
   ProfileRankSide,
@@ -25,15 +22,10 @@ import RankIcon from "../../RankIcon";
 import SupporterBadge from "../../SupporterBadge";
 import Button from "../../ui/Button";
 import Section from "../../ui/Section";
+import PlayerMatchesSection from "./PlayerMatchesSection";
 import ProfileDeckRow from "./ProfileDeckRow";
-import ProfileListItemMatch from "./ProfileListItemMatch";
 import PublicDeckView from "./PublicDeckView";
 import PublicMatchView from "./PublicMatchView";
-
-/** How many matches everyone can see; the server enforces the same number. */
-const PUBLIC_MATCHES = 5;
-/** Page size for supporters browsing past the public window. */
-const HISTORY_PAGE = 25;
 
 function RankBlock({
   title,
@@ -150,96 +142,6 @@ function FormatsSummary({
   );
 }
 
-function RecentMatches({ id }: { id: string }): JSX.Element | null {
-  const history = useHistory();
-  const [page, setPage] = useState<PlayerMatchesPage | null>(null);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [showPatreonPopup, setShowPatreonPopup] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    setPage(null);
-    getPlayerMatches({ arenaId: id }, PUBLIC_MATCHES)
-      .then((p) => p ?? getPlayerMatches({ username: id }, PUBLIC_MATCHES))
-      .then((p) => {
-        if (!cancelled && p) setPage(p);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [id]);
-
-  const loadMore = useCallback(() => {
-    if (!page || loadingMore) return;
-    setLoadingMore(true);
-    getPlayerMatches({ arenaId: id }, HISTORY_PAGE, page.matches.length)
-      .then(
-        (p) =>
-          p ??
-          getPlayerMatches({ username: id }, HISTORY_PAGE, page.matches.length)
-      )
-      .then((p) => {
-        setLoadingMore(false);
-        if (p && p.matches.length > 0) {
-          setPage({
-            ...p,
-            matches: [...page.matches, ...p.matches],
-          });
-        }
-      });
-  }, [id, page, loadingMore]);
-
-  const openMatch = useCallback(
-    (row: PlayerMatchRow) => {
-      history.push(
-        `/profile/${encodeURIComponent(id)}/match/${encodeURIComponent(
-          row.match_id
-        )}`
-      );
-    },
-    [history, id]
-  );
-
-  if (!page || page.total === 0) return null;
-
-  const hasMore = page.matches.length < page.total;
-
-  return (
-    <Section
-      style={{ flexDirection: "column", padding: "16px", margin: "16px 0 0" }}
-    >
-      <div className="profile-section-title">Recent matches</div>
-      {page.matches.map((row) => (
-        <ProfileListItemMatch
-          row={row}
-          key={`profile-match-${row.match_id}`}
-          openMatchCallback={openMatch}
-        />
-      ))}
-      {hasMore ? (
-        <Button
-          style={{ margin: "16px auto 0" }}
-          text={
-            loadingMore
-              ? "Loading..."
-              : `Show more (${page.matches.length} of ${page.total})`
-          }
-          // Full history is a Standard-tier perk; everyone else gets the
-          // upgrade pitch instead of another page.
-          onClick={
-            page.full_access ? loadMore : (): void => setShowPatreonPopup(true)
-          }
-          disabled={loadingMore}
-        />
-      ) : null}
-      {showPatreonPopup ? (
-        <PatreonInfo closeCallback={(): void => setShowPatreonPopup(false)} />
-      ) : null}
-    </Section>
-  );
-}
-
-/* eslint-disable no-nested-ternary */
 /**
  * The player's decks with their records — a Standard-tier perk. Non-patrons
  * see the section with the upgrade pitch instead of the list.
@@ -307,6 +209,7 @@ function DecksSection({ id }: { id: string }): JSX.Element | null {
   );
 }
 
+/* eslint-disable no-nested-ternary */
 function ProfileContent({ id }: { id: string }): JSX.Element {
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [missing, setMissing] = useState(false);
@@ -408,7 +311,7 @@ function ProfileContent({ id }: { id: string }): JSX.Element {
           </div>
 
           <DecksSection id={id} />
-          <RecentMatches id={id} />
+          <PlayerMatchesSection id={id} />
         </>
       )}
     </div>

--- a/src/components/views/profile/ViewProfile.tsx
+++ b/src/components/views/profile/ViewProfile.tsx
@@ -1,0 +1,458 @@
+import { useCallback, useEffect, useState } from "react";
+import { useHistory, useRouteMatch } from "react-router-dom";
+
+import { DEFAULT_AVATAR } from "../../../constants";
+import {
+  getPlayerDecks,
+  getPlayerMatches,
+  getPlayerProfile,
+  PlayerDeckRow,
+  PlayerDecksPage,
+  PlayerMatchesPage,
+  PlayerMatchRow,
+  PlayerProfile,
+  ProfileAccount,
+  ProfileRankSide,
+  RecentRecord,
+} from "../../../data/publicProfiles";
+import cleanUsername from "../../../utils/cleanUsername";
+import formatPercent from "../../../utils/formatPercent";
+import getEventFormat from "../../../utils/getEventFormat";
+import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
+import timeAgo from "../../../utils/timeAgo";
+import PatreonInfo from "../../popups/PatreonInfo";
+import RankIcon from "../../RankIcon";
+import SupporterBadge from "../../SupporterBadge";
+import Button from "../../ui/Button";
+import Section from "../../ui/Section";
+import ProfileDeckRow from "./ProfileDeckRow";
+import ProfileListItemMatch from "./ProfileListItemMatch";
+import PublicDeckView from "./PublicDeckView";
+import PublicMatchView from "./PublicMatchView";
+
+/** How many matches everyone can see; the server enforces the same number. */
+const PUBLIC_MATCHES = 5;
+/** Page size for supporters browsing past the public window. */
+const HISTORY_PAGE = 25;
+
+function RankBlock({
+  title,
+  rank,
+  record,
+  format,
+}: {
+  title: string;
+  rank: ProfileRankSide | null;
+  /** Wins/losses over the last 30 days — season totals reset mid-story. */
+  record: RecentRecord | null;
+  format: "constructed" | "limited";
+}): JSX.Element {
+  // "Spark" is the placeholder a failed rank read writes; its numbers are
+  // just as bogus as its class, so show the whole side as unranked.
+  const isPlaceholder = rank?.class === "Spark";
+  const cls = !rank?.class || isPlaceholder ? "Unranked" : rank.class;
+  const wins = record?.wins ?? 0;
+  const losses = record?.losses ?? 0;
+  const games = wins + losses;
+
+  let label = cls === "Unranked" ? "Unranked" : `${cls} ${rank?.level ?? ""}`;
+  if (cls === "Mythic") {
+    label =
+      (rank?.leaderboardPlace ?? 0) > 0
+        ? `Mythic #${rank?.leaderboardPlace}`
+        : `Mythic ${(rank?.percentile ?? 0).toFixed(2)}%`;
+  }
+
+  return (
+    <div className="profile-rank-block">
+      <div className="profile-rank-title">{title}</div>
+      <RankIcon
+        rank={cls}
+        tier={rank?.level ?? 0}
+        step={rank?.step}
+        percentile={rank?.percentile ?? 0}
+        leaderboardPlace={rank?.leaderboardPlace ?? 0}
+        format={format}
+      />
+      <div className="profile-rank-label">{label}</div>
+      {games > 0 ? (
+        <div className="profile-rank-record">
+          {wins}-{losses}
+          <span
+            style={{
+              color: wins / games >= 0.5 ? "var(--color-g)" : "var(--color-r)",
+              marginLeft: "6px",
+            }}
+          >
+            {((wins / games) * 100).toFixed(0)}%
+          </span>
+        </div>
+      ) : (
+        <div className="profile-rank-record">No recent games</div>
+      )}
+    </div>
+  );
+}
+
+/** The visible account's ranks, on the right side of the banner. */
+function BannerRanks({
+  account,
+  recent,
+}: {
+  account: ProfileAccount;
+  recent: PlayerProfile["recent_30d"];
+}): JSX.Element {
+  return (
+    <div className="profile-banner-ranks">
+      <div className="profile-rank-blocks">
+        <RankBlock
+          title="Constructed"
+          rank={account.constructed}
+          record={recent?.constructed ?? null}
+          format="constructed"
+        />
+        <RankBlock
+          title="Limited"
+          rank={account.limited}
+          record={recent?.limited ?? null}
+          format="limited"
+        />
+      </div>
+      <div className="profile-ranks-updated">Record over the last 30 days</div>
+    </div>
+  );
+}
+
+/** "Timeless 95% · Limited 3% · Brawl 2%" chips from raw event-id counts. */
+function FormatsSummary({
+  counts,
+}: {
+  counts: Record<string, number>;
+}): JSX.Element | null {
+  const byFormat: Record<string, number> = {};
+  let total = 0;
+  Object.entries(counts).forEach(([eventId, n]) => {
+    const fmt = getEventFormat(eventId);
+    byFormat[fmt] = (byFormat[fmt] ?? 0) + n;
+    total += n;
+  });
+  if (total === 0) return null;
+
+  const entries = Object.entries(byFormat).sort((a, b) => b[1] - a[1]);
+  return (
+    <div className="profile-formats">
+      {entries.map(([fmt, n]) => (
+        <div className="profile-format-chip" key={`fmt-${fmt}`}>
+          {fmt} <span>{formatPercent(n / total)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RecentMatches({ id }: { id: string }): JSX.Element | null {
+  const history = useHistory();
+  const [page, setPage] = useState<PlayerMatchesPage | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [showPatreonPopup, setShowPatreonPopup] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPage(null);
+    getPlayerMatches({ arenaId: id }, PUBLIC_MATCHES)
+      .then((p) => p ?? getPlayerMatches({ username: id }, PUBLIC_MATCHES))
+      .then((p) => {
+        if (!cancelled && p) setPage(p);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const loadMore = useCallback(() => {
+    if (!page || loadingMore) return;
+    setLoadingMore(true);
+    getPlayerMatches({ arenaId: id }, HISTORY_PAGE, page.matches.length)
+      .then(
+        (p) =>
+          p ??
+          getPlayerMatches({ username: id }, HISTORY_PAGE, page.matches.length)
+      )
+      .then((p) => {
+        setLoadingMore(false);
+        if (p && p.matches.length > 0) {
+          setPage({
+            ...p,
+            matches: [...page.matches, ...p.matches],
+          });
+        }
+      });
+  }, [id, page, loadingMore]);
+
+  const openMatch = useCallback(
+    (row: PlayerMatchRow) => {
+      history.push(
+        `/profile/${encodeURIComponent(id)}/match/${encodeURIComponent(
+          row.match_id
+        )}`
+      );
+    },
+    [history, id]
+  );
+
+  if (!page || page.total === 0) return null;
+
+  const hasMore = page.matches.length < page.total;
+
+  return (
+    <Section
+      style={{ flexDirection: "column", padding: "16px", margin: "16px 0 0" }}
+    >
+      <div className="profile-section-title">Recent matches</div>
+      {page.matches.map((row) => (
+        <ProfileListItemMatch
+          row={row}
+          key={`profile-match-${row.match_id}`}
+          openMatchCallback={openMatch}
+        />
+      ))}
+      {hasMore ? (
+        <Button
+          style={{ margin: "16px auto 0" }}
+          text={
+            loadingMore
+              ? "Loading..."
+              : `Show more (${page.matches.length} of ${page.total})`
+          }
+          // Full history is a Standard-tier perk; everyone else gets the
+          // upgrade pitch instead of another page.
+          onClick={
+            page.full_access ? loadMore : (): void => setShowPatreonPopup(true)
+          }
+          disabled={loadingMore}
+        />
+      ) : null}
+      {showPatreonPopup ? (
+        <PatreonInfo closeCallback={(): void => setShowPatreonPopup(false)} />
+      ) : null}
+    </Section>
+  );
+}
+
+/* eslint-disable no-nested-ternary */
+/**
+ * The player's decks with their records — a Standard-tier perk. Non-patrons
+ * see the section with the upgrade pitch instead of the list.
+ */
+function DecksSection({ id }: { id: string }): JSX.Element | null {
+  const history = useHistory();
+  const [page, setPage] = useState<PlayerDecksPage | null>(null);
+  const [showPatreonPopup, setShowPatreonPopup] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPage(null);
+    getPlayerDecks({ arenaId: id })
+      .then((p) => p ?? getPlayerDecks({ username: id }))
+      .then((p) => {
+        if (!cancelled && p) setPage(p);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const openDeck = useCallback(
+    (row: PlayerDeckRow) => {
+      history.push(
+        `/profile/${encodeURIComponent(id)}/deck/${encodeURIComponent(row.id)}`
+      );
+    },
+    [history, id]
+  );
+
+  if (!page) return null;
+  if (page.full_access && page.decks.length === 0) return null;
+
+  return (
+    <Section
+      style={{ flexDirection: "column", padding: "16px", margin: "16px 0 0" }}
+    >
+      <div className="profile-section-title">Decks</div>
+      {page.full_access ? (
+        <div className="decks-table-wrapper">
+          {page.decks
+            // A failed parse can upload an empty deck; there is nothing to
+            // show or open for it.
+            .filter((row) => row.id && (row.deck?.mainDeck?.length ?? 0) > 0)
+            .map((row) => (
+              <ProfileDeckRow
+                key={`profile-deck-${row.id}`}
+                row={row}
+                clickDeck={openDeck}
+              />
+            ))}
+        </div>
+      ) : (
+        <Button
+          style={{ margin: "8px auto" }}
+          text="See this player's decks"
+          onClick={(): void => setShowPatreonPopup(true)}
+        />
+      )}
+      {showPatreonPopup ? (
+        <PatreonInfo closeCallback={(): void => setShowPatreonPopup(false)} />
+      ) : null}
+    </Section>
+  );
+}
+
+function ProfileContent({ id }: { id: string }): JSX.Element {
+  const [profile, setProfile] = useState<PlayerProfile | null>(null);
+  const [missing, setMissing] = useState(false);
+
+  useEffect(() => {
+    if (!id) return undefined;
+    setProfile(null);
+    setMissing(false);
+    let cancelled = false;
+    // The id is an arena persona id when coming from the feeds; fall back to
+    // a username lookup so /profile/<name> links work too.
+    getPlayerProfile({ arenaId: id })
+      .then((p) => p ?? getPlayerProfile({ username: id }))
+      .then((p) => {
+        if (cancelled) return;
+        if (p) setProfile(p);
+        else setMissing(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const bannerUrl = profile?.background?.imageUrl;
+
+  return (
+    <div className="profile-view">
+      {missing ? (
+        <Section
+          style={{
+            marginTop: "16px",
+            padding: "48px",
+            flexDirection: "column",
+            textAlign: "center",
+          }}
+        >
+          <div style={{ color: "var(--color-text-dark)" }}>
+            This profile is private or does not exist.
+          </div>
+        </Section>
+      ) : !profile ? (
+        <Section style={{ marginTop: "16px", padding: "48px" }}>
+          <div className="loading-sign" style={{ margin: "auto" }} />
+        </Section>
+      ) : (
+        <>
+          <div
+            className={`profile-banner${bannerUrl ? " has-image" : ""}`}
+            style={
+              bannerUrl ? { backgroundImage: `url(${bannerUrl})` } : undefined
+            }
+          >
+            <div className="profile-banner-inner">
+              <div className="profile-banner-left">
+                <div
+                  className="profile-avatar"
+                  style={{
+                    backgroundImage: `url(${
+                      profile.avatar_url || DEFAULT_AVATAR
+                    })`,
+                  }}
+                />
+                <div className="profile-identity">
+                  <div className="profile-username">
+                    {profile.username ||
+                      cleanUsername(
+                        getPlayerNameWithoutSuffix(
+                          profile.account?.display_name || "Planeswalker"
+                        )
+                      )}
+                    {profile.supporter_tier > 0 ? (
+                      <SupporterBadge tier={profile.supporter_tier} />
+                    ) : null}
+                  </div>
+                  {profile.member_since ? (
+                    <div className="profile-member-since">
+                      Playing with MTGATool since{" "}
+                      {new Date(profile.member_since).toLocaleDateString(
+                        undefined,
+                        { year: "numeric", month: "long" }
+                      )}
+                    </div>
+                  ) : null}
+                  {profile.last_seen ? (
+                    <div className="profile-member-since">
+                      Last seen {timeAgo(new Date(profile.last_seen).getTime())}
+                    </div>
+                  ) : null}
+                  <FormatsSummary counts={profile.format_counts ?? {}} />
+                </div>
+              </div>
+              {profile.account ? (
+                <BannerRanks
+                  account={profile.account}
+                  recent={profile.recent_30d}
+                />
+              ) : null}
+            </div>
+          </div>
+
+          <DecksSection id={id} />
+          <RecentMatches id={id} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Public player profile (/profile/<arenaId or username>). Everything shown
+ * comes from the get_player_profile / get_player_matches RPCs, which serve
+ * only public fields, for only one Arena account per player (their pinned
+ * one, or the latest played), and answer with nothing for private-mode
+ * profiles — so this screen cannot distinguish "private" from "does not
+ * exist", by design. Arena ids are accepted as input but never displayed.
+ * /profile/<id>/match/<matchId> opens a match's public view, and
+ * /profile/<id>/deck/<hash> a deck's record and its matches (patron perk).
+ */
+export default function ViewProfile(): JSX.Element {
+  const matchRoute = useRouteMatch<{ id: string; matchId: string }>(
+    "/profile/:id/match/:matchId"
+  );
+  const deckRoute = useRouteMatch<{ id: string; hash: string }>(
+    "/profile/:id/deck/:hash"
+  );
+  const profileRoute = useRouteMatch<{ id: string }>("/profile/:id");
+
+  if (matchRoute) {
+    return (
+      <PublicMatchView
+        profileId={decodeURIComponent(matchRoute.params.id)}
+        matchId={decodeURIComponent(matchRoute.params.matchId)}
+      />
+    );
+  }
+  if (deckRoute) {
+    return (
+      <PublicDeckView
+        profileId={decodeURIComponent(deckRoute.params.id)}
+        deckId={decodeURIComponent(deckRoute.params.hash)}
+      />
+    );
+  }
+
+  const id = profileRoute?.params.id
+    ? decodeURIComponent(profileRoute.params.id)
+    : "";
+  return <ProfileContent id={id} />;
+}

--- a/src/components/views/profile/ViewProfile.tsx
+++ b/src/components/views/profile/ViewProfile.tsx
@@ -16,6 +16,7 @@ import cleanUsername from "../../../utils/cleanUsername";
 import formatPercent from "../../../utils/formatPercent";
 import getEventFormat from "../../../utils/getEventFormat";
 import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
+import safeDecodeURIComponent from "../../../utils/safeDecodeURIComponent";
 import timeAgo from "../../../utils/timeAgo";
 import PatreonInfo from "../../popups/PatreonInfo";
 import PublicLoading from "../../PublicLoading";
@@ -341,22 +342,22 @@ export default function ViewProfile(): JSX.Element {
   if (matchRoute) {
     return (
       <PublicMatchView
-        profileId={decodeURIComponent(matchRoute.params.id)}
-        matchId={decodeURIComponent(matchRoute.params.matchId)}
+        profileId={safeDecodeURIComponent(matchRoute.params.id)}
+        matchId={safeDecodeURIComponent(matchRoute.params.matchId)}
       />
     );
   }
   if (deckRoute) {
     return (
       <PublicDeckView
-        profileId={decodeURIComponent(deckRoute.params.id)}
-        deckId={decodeURIComponent(deckRoute.params.hash)}
+        profileId={safeDecodeURIComponent(deckRoute.params.id)}
+        deckId={safeDecodeURIComponent(deckRoute.params.hash)}
       />
     );
   }
 
   const id = profileRoute?.params.id
-    ? decodeURIComponent(profileRoute.params.id)
+    ? safeDecodeURIComponent(profileRoute.params.id)
     : "";
   return <ProfileContent id={id} />;
 }

--- a/src/components/views/settings/AccountSettingsPanel.tsx
+++ b/src/components/views/settings/AccountSettingsPanel.tsx
@@ -237,9 +237,14 @@ export default function AccountSettingsPanel(
     Promise.all([fetchOwnArenaAccounts(), fetchOwnVisibleArenaId()]).then(
       ([accounts, pinned]) => {
         setOwnAccounts(accounts);
-        setVisibleAccount(
-          pinned && accounts.some((a) => a.arenaId === pinned) ? pinned : ""
-        );
+        const pinValid = !!pinned && accounts.some((a) => a.arenaId === pinned);
+        setVisibleAccount(pinValid ? (pinned as string) : "");
+        // A pin pointing at an account no longer linked would silently keep
+        // steering the public profile; clear it. Only when the account list
+        // actually loaded — an empty answer might be a failed fetch.
+        if (pinned && !pinValid && accounts.length > 0) {
+          setVisibleArenaAccount(null);
+        }
       }
     );
   }, []);

--- a/src/components/views/settings/AccountSettingsPanel.tsx
+++ b/src/components/views/settings/AccountSettingsPanel.tsx
@@ -11,7 +11,11 @@ import { cloudLogout, cloudUpdatePassword } from "../../../data/cloudAuth";
 import { isCloudActive } from "../../../data/cloudSync";
 import { TIER_NAMES } from "../../../data/entitlement";
 import {
+  fetchOwnArenaAccounts,
+  fetchOwnVisibleArenaId,
+  OwnArenaAccount,
   setProfilePrivate,
+  setVisibleArenaAccount,
   updateUsername,
   uploadAvatar,
 } from "../../../data/profile";
@@ -27,10 +31,12 @@ import useSupporter from "../../../hooks/useSupporter";
 import reduxAction from "../../../redux/reduxAction";
 import { AppState } from "../../../redux/stores/rendererStore";
 import getLocalSetting from "../../../utils/getLocalSetting";
+import getPlayerNameWithoutSuffix from "../../../utils/getPlayerNameWithoutSuffix";
 import setLocalSetting from "../../../utils/setLocalSetting";
 import vodiFn from "../../../utils/voidfn";
 import SupporterTierIcon, { TIERS } from "../../SupporterTierIcon";
 import Button from "../../ui/Button";
+import Select from "../../ui/Select";
 import Toggle from "../../ui/Toggle";
 import { SettingsPanelProps } from "./ViewSettings";
 
@@ -222,6 +228,38 @@ export default function AccountSettingsPanel(
     [fetchAvatar, avatarKey]
   );
 
+  // Which Arena account the public profile shows. "" is the default
+  // (most recently played); anything else pins that account.
+  const [ownAccounts, setOwnAccounts] = useState<OwnArenaAccount[]>([]);
+  const [visibleAccount, setVisibleAccount] = useState("");
+
+  useEffect(() => {
+    Promise.all([fetchOwnArenaAccounts(), fetchOwnVisibleArenaId()]).then(
+      ([accounts, pinned]) => {
+        setOwnAccounts(accounts);
+        setVisibleAccount(
+          pinned && accounts.some((a) => a.arenaId === pinned) ? pinned : ""
+        );
+      }
+    );
+  }, []);
+
+  const changeVisibleAccount = useCallback((arenaId: string) => {
+    setVisibleAccount(arenaId);
+    setVisibleArenaAccount(arenaId || null);
+  }, []);
+
+  const formatAccountOption = useCallback(
+    (arenaId: string | number) => {
+      if (!arenaId) return "Most recent (default)";
+      const acc = ownAccounts.find((a) => a.arenaId === arenaId);
+      return acc?.displayName
+        ? getPlayerNameWithoutSuffix(acc.displayName)
+        : String(arenaId);
+    },
+    [ownAccounts]
+  );
+
   const setPrivateMode = useCallback(
     (value: boolean) => {
       if (value) {
@@ -327,6 +365,17 @@ export default function AccountSettingsPanel(
         style={{ margin: "auto" }}
         callback={setPrivateMode}
       />
+      {ownAccounts.length > 1 ? (
+        <div className="centered-setting-container">
+          <label>Arena account shown on your public profile:</label>
+          <Select<string>
+            options={["", ...ownAccounts.map((a) => a.arenaId)]}
+            current={visibleAccount}
+            optionFormatter={formatAccountOption}
+            callback={changeVisibleAccount}
+          />
+        </div>
+      ) : null}
       <p
         style={{
           textAlign: "center",

--- a/src/data/database.types.ts
+++ b/src/data/database.types.ts
@@ -413,31 +413,37 @@ export type Database = {
           avatar_url: string | null;
           background: Json | null;
           created_at: string;
+          display_name: string | null;
           id: string;
           is_private: boolean;
           supporter_tier: number;
           updated_at: string;
           username: string | null;
+          visible_arena_id: string | null;
         };
         Insert: {
           avatar_url?: string | null;
           background?: Json | null;
           created_at?: string;
+          display_name?: string | null;
           id: string;
           is_private?: boolean;
           supporter_tier?: number;
           updated_at?: string;
           username?: string | null;
+          visible_arena_id?: string | null;
         };
         Update: {
           avatar_url?: string | null;
           background?: Json | null;
           created_at?: string;
+          display_name?: string | null;
           id?: string;
           is_private?: boolean;
           supporter_tier?: number;
           updated_at?: string;
           username?: string | null;
+          visible_arena_id?: string | null;
         };
         Relationships: [];
       };
@@ -458,6 +464,32 @@ export type Database = {
       };
       get_shared_deck: {
         Args: { p_share_id: string };
+        Returns: Json;
+      };
+      get_player_profile: {
+        Args: { p_arena_id?: string; p_username?: string };
+        Returns: Json;
+      };
+      get_player_matches: {
+        Args: {
+          p_arena_id?: string;
+          p_username?: string;
+          p_limit?: number;
+          p_offset?: number;
+          p_deck_id?: string;
+        };
+        Returns: Json;
+      };
+      get_player_decks: {
+        Args: { p_arena_id?: string; p_username?: string };
+        Returns: Json;
+      };
+      get_public_match: {
+        Args: {
+          p_match_id: string;
+          p_arena_id?: string;
+          p_username?: string;
+        };
         Returns: Json;
       };
       get_public_profiles: {

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -57,6 +57,7 @@ export async function updateUsername(username: string): Promise<boolean> {
     const { error } = await supabase.from("profiles").upsert({
       id: uid,
       username,
+      display_name: username,
       updated_at: new Date().toISOString(),
     });
     if (error) {
@@ -130,5 +131,74 @@ export async function fetchOwnAvatarUrl(): Promise<string | null> {
     return (data?.avatar_url as string) ?? null;
   } catch {
     return null;
+  }
+}
+
+/** An Arena account linked to the current login, for the settings selector. */
+export interface OwnArenaAccount {
+  arenaId: string;
+  displayName: string | null;
+  lastSeenAt: string | null;
+}
+
+/**
+ * The login's linked Arena accounts, most recently played first. Own rows
+ * only (RLS); used to pick which account the public profile shows.
+ */
+export async function fetchOwnArenaAccounts(): Promise<OwnArenaAccount[]> {
+  try {
+    const uid = await currentUserId();
+    if (!uid) return [];
+    const { data, error } = await supabase
+      .from("arena_accounts")
+      .select("*")
+      .eq("user_id", uid)
+      .order("last_seen_at", { ascending: false });
+    if (error || !data) return [];
+    return data.map((row) => ({
+      arenaId: row.arena_id,
+      displayName: row.display_name,
+      lastSeenAt: row.last_seen_at,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** The account the login has pinned to its public profile, or null. */
+export async function fetchOwnVisibleArenaId(): Promise<string | null> {
+  try {
+    const uid = await currentUserId();
+    if (!uid) return null;
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("id", uid)
+      .maybeSingle();
+    if (error) return null;
+    return data?.visible_arena_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pin which Arena account the public profile shows, or null to go back to
+ * "most recently played". Best-effort; never throws.
+ */
+export async function setVisibleArenaAccount(
+  arenaId: string | null
+): Promise<void> {
+  try {
+    const uid = await currentUserId();
+    if (!uid) return;
+    await supabase.from("profiles").upsert({
+      id: uid,
+      visible_arena_id: arenaId,
+      updated_at: new Date().toISOString(),
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("[profile] setVisibleArenaAccount failed:", e);
   }
 }

--- a/src/data/publicProfiles.ts
+++ b/src/data/publicProfiles.ts
@@ -162,8 +162,10 @@ export interface PublicMatchRank {
 
 export interface PlayerMatchRow {
   match_id: string;
-  event_id: string;
-  played_at: string;
+  /** Nullable in the schema; the uploader always writes them, but honesty
+   * here keeps the render guards in place. */
+  event_id: string | null;
+  played_at: string | null;
   deck_name: string | null;
   deck_tile_id: number | null;
   /** Main-deck card ids, present only when the deck has no tile of its own. */
@@ -185,8 +187,8 @@ export interface PlayerMatchRow {
  */
 export interface PublicMatch {
   match_id: string;
-  event_id: string;
-  played_at: string;
+  event_id: string | null;
+  played_at: string | null;
   duration: number | null;
   best_of: number | null;
   player_wins: number;
@@ -214,7 +216,7 @@ export interface PlayerDeckRow {
   id: string;
   games: number;
   wins: number;
-  last_played: string;
+  last_played: string | null;
   deck: {
     name?: string;
     deckTileId?: number;

--- a/src/data/publicProfiles.ts
+++ b/src/data/publicProfiles.ts
@@ -179,8 +179,9 @@ export interface PlayerMatchRow {
 }
 
 /**
- * The public view of one match: the played deck and the result. No arena
- * ids, no player names, no action log, no game telemetry.
+ * The public view of one match: the played deck, the result, the opponent's
+ * in-game name and rank, and the action log. No arena ids and no per-game
+ * telemetry (hands drawn, cards seen).
  */
 export interface PublicMatch {
   match_id: string;

--- a/src/data/publicProfiles.ts
+++ b/src/data/publicProfiles.ts
@@ -104,3 +104,225 @@ export async function getPublicProfiles(
     return out;
   }
 }
+
+// Field names below come from the RPC's jsonb, hence the database spelling.
+/* eslint-disable camelcase */
+
+/** One rank side as stored in arena_ranks jsonb. */
+export interface ProfileRankSide {
+  class?: string;
+  level?: number;
+  step?: number;
+  percentile?: number;
+  leaderboardPlace?: number;
+  matchesWon?: number;
+  matchesLost?: number;
+  seasonOrdinal?: number;
+}
+
+/**
+ * The single Arena account a profile exposes (the owner's pinned one, or the
+ * most recently played). Deliberately carries no arena id.
+ */
+export interface ProfileAccount {
+  display_name: string | null;
+  constructed: ProfileRankSide | null;
+  limited: ProfileRankSide | null;
+  ranks_updated_at: string | null;
+}
+
+export interface RecentRecord {
+  wins: number;
+  losses: number;
+}
+
+export interface PlayerProfile {
+  username: string | null;
+  avatar_url: string | null;
+  supporter_tier: number;
+  background: { imageUrl?: string } | null;
+  member_since: string | null;
+  /** When the visible account last uploaded anything. */
+  last_seen: string | null;
+  account: ProfileAccount | null;
+  /** Match records over the last 30 days — season totals reset mid-story. */
+  recent_30d: { constructed: RecentRecord; limited: RecentRecord } | null;
+  /** Matches played per raw event id, for the formats summary. */
+  format_counts: Record<string, number>;
+}
+
+/** Rank as embedded in a stored match (both players'). */
+export interface PublicMatchRank {
+  rank: string | null;
+  tier: number | null;
+  step: number | null;
+  percentile: number | null;
+  leaderboardPlace: number | null;
+}
+
+export interface PlayerMatchRow {
+  match_id: string;
+  event_id: string;
+  played_at: string;
+  deck_name: string | null;
+  deck_tile_id: number | null;
+  /** Main-deck card ids, present only when the deck has no tile of its own. */
+  fallback_ids: number[] | null;
+  opp_name: string | null;
+  player_rank: PublicMatchRank | null;
+  opp_rank: PublicMatchRank | null;
+  player_deck_colors: number | null;
+  opp_deck_colors: number | null;
+  player_wins: number;
+  player_losses: number;
+  duration: number | null;
+}
+
+/**
+ * The public view of one match: the played deck and the result. No arena
+ * ids, no player names, no action log, no game telemetry.
+ */
+export interface PublicMatch {
+  match_id: string;
+  event_id: string;
+  played_at: string;
+  duration: number | null;
+  best_of: number | null;
+  player_wins: number;
+  player_losses: number;
+  player_deck: {
+    name?: string;
+    deckTileId?: number;
+    mainDeck?: { id: number; quantity: number }[];
+    sideboard?: { id: number; quantity: number }[];
+  } | null;
+  opp_deck_colors: number | null;
+  opp_name: string | null;
+  /** Plain text for old matches, a structured object for new ones. */
+  action_log: string | Record<string, unknown> | null;
+  player_rank: PublicMatchRank | null;
+  opp_rank: PublicMatchRank | null;
+}
+
+/**
+ * One aggregated deck from the player's uploaded matches. Versions are
+ * unified by Arena deck id; the record spans all of them and `deck` is the
+ * latest version's snapshot.
+ */
+export interface PlayerDeckRow {
+  id: string;
+  games: number;
+  wins: number;
+  last_played: string;
+  deck: {
+    name?: string;
+    deckTileId?: number;
+    colors?: number;
+    mainDeck?: { id: number; quantity: number }[];
+    sideboard?: { id: number; quantity: number }[];
+  } | null;
+}
+
+export interface PlayerDecksPage {
+  decks: PlayerDeckRow[];
+  full_access: boolean;
+}
+
+export interface PlayerMatchesPage {
+  matches: PlayerMatchRow[];
+  total: number;
+  /** Whether the CALLER may page past the first five (Standard+ patron). */
+  full_access: boolean;
+}
+
+/* eslint-enable camelcase */
+
+/**
+ * A player's public profile, by arena persona id or username. Resolves to
+ * null for private-mode profiles and unknown players alike — the screen
+ * cannot tell the difference, deliberately.
+ */
+export async function getPlayerProfile(query: {
+  arenaId?: string;
+  username?: string;
+}): Promise<PlayerProfile | null> {
+  try {
+    const { data, error } = await supabase.rpc("get_player_profile", {
+      p_arena_id: query.arenaId,
+      p_username: query.username,
+    });
+    if (error || !data) return null;
+    return data as unknown as PlayerProfile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A page of the player's public match list, for the same account the profile
+ * shows. The server caps everyone at the last 5 unless the caller's Patreon
+ * entitlement is Standard tier or higher — the limit passed here is a
+ * request, not a promise.
+ */
+export async function getPlayerMatches(
+  query: { arenaId?: string; username?: string },
+  limit = 5,
+  offset = 0,
+  deckId?: string
+): Promise<PlayerMatchesPage | null> {
+  try {
+    const { data, error } = await supabase.rpc("get_player_matches", {
+      p_arena_id: query.arenaId,
+      p_username: query.username,
+      p_limit: limit,
+      p_offset: offset,
+      p_deck_id: deckId,
+    });
+    if (error || !data) return null;
+    return data as unknown as PlayerMatchesPage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The player's decks with records, aggregated from their uploaded matches.
+ * A Standard-tier perk: non-patron callers get an empty list and
+ * full_access=false.
+ */
+export async function getPlayerDecks(query: {
+  arenaId?: string;
+  username?: string;
+}): Promise<PlayerDecksPage | null> {
+  try {
+    const { data, error } = await supabase.rpc("get_player_decks", {
+      p_arena_id: query.arenaId,
+      p_username: query.username,
+    });
+    if (error || !data) return null;
+    return data as unknown as PlayerDecksPage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One match's public view, scoped to the same profile the match list came
+ * from. Null for private profiles and unknown ids alike.
+ */
+export async function getPublicMatch(
+  matchId: string,
+  query: { arenaId?: string; username?: string }
+): Promise<PublicMatch | null> {
+  try {
+    const { data, error } = await supabase.rpc("get_public_match", {
+      p_match_id: matchId,
+      p_arena_id: query.arenaId,
+      p_username: query.username,
+    });
+    if (error || !data) return null;
+    return data as unknown as PublicMatch;
+  } catch {
+    return null;
+  }
+}

--- a/src/data/sharedDecks.ts
+++ b/src/data/sharedDecks.ts
@@ -34,6 +34,8 @@ export interface SharedDeckOwner {
 export interface SharedDeckPayload {
   deck: SharedDeckSnapshot;
   updated_at: string;
+  /** Arena deck id, for the recent-matches list. Null for private owners. */
+  deck_id: string | null;
   owner: SharedDeckOwner | null;
   winrate: { wins: number; losses: number } | null;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -44,6 +44,7 @@
 @import "scss/historyStats.scss";
 @import "scss/liveDraft.scss";
 @import "scss/segmentedToggle.scss";
+@import "scss/profileView.scss";
 @import "scss/CardsWinrateView.scss";
 
 @import "scss/CompletionProgressBar.scss";

--- a/src/scss/decksView.scss
+++ b/src/scss/decksView.scss
@@ -191,6 +191,23 @@
 // page does not have), and .app-wrapper-back's ::after overlay both covers
 // unpositioned content and eats its pointer events — cards were unhoverable
 // until this stacked above it.
+// Same shell for the signed-out profile page.
+.public-profile-page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 24px;
+
+  .profile-view {
+    padding-bottom: 48px;
+  }
+}
+
 .shared-deck-page {
   position: absolute;
   top: 0;
@@ -256,34 +273,21 @@
       line-height: 24px;
     }
 
-    .shared-deck-owner {
+    .shared-deck-owner.has-profile {
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .shared-deck-owner {
       display: flex;
       align-items: center;
       gap: 6px;
       color: var(--color-text);
       font-size: 13px;
       font-family: var(--main-font-name-it);
-    }
-  }
-
-  .shared-deck-record {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    margin: auto 16px;
-
-    .record {
-      font-size: 22px;
-      color: var(--color-text);
-    }
-
-    .percent {
-      font-size: 16px;
-    }
-
-    .record-label {
-      font-size: 12px;
-      color: var(--color-text-dark);
     }
   }
 
@@ -316,5 +320,27 @@
   .shared-deck-cta {
     color: var(--color-text-link);
     cursor: pointer;
+  }
+}
+
+// Used inside .shared-deck-page AND on the profile deck view.
+.shared-deck-record {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: auto 16px;
+
+  .record {
+    font-size: 22px;
+    color: var(--color-text);
+  }
+
+  .percent {
+    font-size: 16px;
+  }
+
+  .record-label {
+    font-size: 12px;
+    color: var(--color-text-dark);
   }
 }

--- a/src/scss/decksView.scss
+++ b/src/scss/decksView.scss
@@ -275,6 +275,8 @@
 
     .shared-deck-owner.has-profile {
     cursor: pointer;
+    color: inherit;
+    text-decoration: none;
 
     &:hover {
       text-decoration: underline;

--- a/src/scss/homeView.scss
+++ b/src/scss/homeView.scss
@@ -109,6 +109,16 @@
         overflow: hidden;
 
         .rank-name {
+          // native button for keyboard access, styled as the text it was
+          border: 0;
+          padding: 0;
+          background: transparent;
+          font: inherit;
+          color: inherit;
+          text-align: inherit;
+          text-indent: inherit;
+          display: block;
+          width: 100%;
           text-overflow: ellipsis;
           white-space: pre;
           overflow: hidden;

--- a/src/scss/popups.scss
+++ b/src/scss/popups.scss
@@ -221,11 +221,25 @@
 
 .patreon-info-pop-top {
   background-color: #f96854;
-  padding: 24px;
+  padding: 32px 24px;
+  position: relative;
+  overflow: hidden;
+
+  .message-sub {
+    position: relative;
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4);
+  }
+}
+
+// Patreon marks drifting behind the header text.
+.patreon-float {
+  position: absolute;
+  color: rgba(255, 255, 255, 0.3);
+  pointer-events: none;
 }
 
 .patreon-info-pop-bottom {
-  padding: 24px;
+  padding: 16px 24px 40px;
 }
 
 .patreon-info-text {
@@ -233,12 +247,32 @@
   margin: 8px;
 }
 
+.patreon-perk {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 11px 24px;
+
+  &:not(:last-of-type) {
+    border-bottom: 1px solid var(--color-line-sep);
+  }
+}
+
+.patreon-perk-dot {
+  width: 9px;
+  height: 9px;
+  min-width: 9px;
+  border-radius: 9px;
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.15);
+}
+
 .patreon-desc-text {
   font-family: var(--main-font-name-it);
   opacity: 0.8;
   text-align: center;
-  margin: 41px 12px 32px;
-  padding-top: 24px;
+  margin: 24px 12px 28px;
+  padding-top: 20px;
   border-top: 1px solid var(--color-back-40);
 }
 

--- a/src/scss/popups.scss
+++ b/src/scss/popups.scss
@@ -254,8 +254,10 @@
   gap: 10px;
   padding: 11px 24px;
 
-  &:not(:last-of-type) {
-    border-bottom: 1px solid var(--color-line-sep);
+  // Adjacent-sibling, not :last-of-type: the description below is also a
+  // div, which would give the final perk a separator too.
+  + .patreon-perk {
+    border-top: 1px solid var(--color-line-sep);
   }
 }
 
@@ -277,6 +279,10 @@
 }
 
 .patreon_link_thin {
+  display: block;
+  border: 0;
+  padding: 0;
+  background-color: transparent;
   background-image: url(../assets/images/button_patreon.png);
   cursor: pointer;
   width: 190px;

--- a/src/scss/profileView.scss
+++ b/src/scss/profileView.scss
@@ -1,0 +1,206 @@
+// Public player profile (/profile/<id>).
+.profile-view {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-bottom: 24px;
+
+  .profile-banner {
+    position: relative;
+    margin-top: 16px;
+    border-radius: 4px;
+    background-color: var(--color-section);
+    background-size: cover;
+    background-position: center 25%;
+    overflow: hidden;
+
+    // Same trick as the shared-deck banner: a gradient rising from the
+    // bottom so the identity stays readable over any art.
+    &.has-image::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        to top,
+        rgba(10, 10, 11, 0.9) 0%,
+        rgba(10, 10, 11, 0.55) 55%,
+        rgba(10, 10, 11, 0.15) 100%
+      );
+      pointer-events: none;
+    }
+
+    > * {
+      position: relative;
+    }
+  }
+
+  .profile-banner-inner {
+    display: flex;
+    align-items: center;
+    padding: 24px;
+  }
+
+  // Two balanced halves: identity on the left, ranks on the right.
+  .profile-banner-left {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .profile-avatar {
+    width: 96px;
+    height: 96px;
+    min-width: 96px;
+    border-radius: 96px;
+    background-size: cover;
+    background-position: center;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  }
+
+  .profile-identity {
+    margin-left: 20px;
+    text-shadow: 2px 2px 5px #000000;
+
+    .profile-username {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 28px;
+      color: var(--color-text-hover);
+    }
+
+    .profile-member-since {
+      margin-top: 4px;
+      font-size: 13px;
+      color: var(--color-text);
+      font-family: var(--main-font-name-it);
+    }
+  }
+
+  // The visible account's ranks, right side of the banner.
+  .profile-banner-ranks {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-shadow: 2px 2px 5px #000000;
+  }
+
+  .profile-formats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+  }
+
+  .profile-format-chip {
+    padding: 2px 10px;
+    border-radius: 12px;
+    background-color: rgba(0, 0, 0, 0.45);
+    font-size: 12px;
+    color: var(--color-text);
+
+    span {
+      color: var(--color-text-hover);
+      margin-left: 4px;
+    }
+  }
+
+  .profile-section-title {
+    font-size: 16px;
+    color: var(--color-text);
+    text-align: center;
+    margin: 0 0 8px;
+  }
+
+  .profile-matches-more {
+    margin-top: 10px;
+    text-align: center;
+    color: var(--color-text-link);
+    cursor: pointer;
+    text-shadow: 2px 2px 5px #000000;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .profile-matches-locked {
+    margin-top: 10px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--color-text);
+    font-family: var(--main-font-name-it);
+    text-shadow: 2px 2px 5px #000000;
+  }
+
+  .profile-rank-blocks {
+    display: flex;
+    justify-content: space-around;
+    gap: 8px;
+  }
+
+  .profile-rank-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 120px;
+    padding: 4px 8px;
+
+    .profile-rank-title {
+      font-size: 13px;
+      color: var(--color-text);
+      font-family: var(--main-font-name-it);
+      margin-bottom: 4px;
+    }
+
+    .profile-rank-label {
+      margin-top: 4px;
+      color: var(--color-text);
+    }
+
+    .profile-rank-record {
+      margin-top: 2px;
+      font-size: 13px;
+      color: var(--color-text-dark);
+    }
+  }
+
+  .profile-ranks-updated {
+    margin-top: 6px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--color-text-disabled);
+    font-family: var(--main-font-name-it);
+  }
+
+  .list-item-right {
+    margin-right: 20px;
+  }
+
+  .list-match-result {
+    min-width: 40px;
+  }
+
+  // Deck list beside the action log, like the private match view.
+  .public-match-grid {
+    display: grid;
+    gap: 16px;
+    margin: 16px 0;
+    grid-template-columns: calc(50% - 8px) calc(50% - 8px);
+    align-items: start;
+
+    &.no-log {
+      grid-template-columns: 100%;
+    }
+
+    @media screen and (max-width: 750px) {
+      grid-template-columns: 100%;
+    }
+  }
+}

--- a/src/scss/profileView.scss
+++ b/src/scss/profileView.scss
@@ -204,3 +204,56 @@
     }
   }
 }
+
+// Slim chrome for signed-out public pages (profiles, and anything the
+// standalone shell hosts). Sticky so the actions survive long deck lists.
+.public-top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 52px;
+  margin: 0 -24px;
+  padding: 0 24px;
+  background-color: var(--color-base);
+  border-bottom: 1px solid var(--color-line-sep);
+
+  .public-top-bar-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    color: var(--color-text-hover);
+
+    img {
+      height: 32px;
+      width: auto;
+    }
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  .public-top-bar-actions {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+// "Log in to compare against your collection!" on public deck/match pages.
+.login-prompt {
+  margin: auto;
+  color: var(--color-text);
+
+  .login-prompt-link {
+    color: var(--color-text-link);
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/scss/profileView.scss
+++ b/src/scss/profileView.scss
@@ -226,6 +226,9 @@
     gap: 10px;
     cursor: pointer;
     color: var(--color-text-hover);
+    border: 0;
+    padding: 0;
+    background: transparent;
 
     img {
       height: 32px;
@@ -251,6 +254,10 @@
   .login-prompt-link {
     color: var(--color-text-link);
     cursor: pointer;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    font: inherit;
 
     &:hover {
       text-decoration: underline;

--- a/src/scss/profileView.scss
+++ b/src/scss/profileView.scss
@@ -285,4 +285,15 @@
     color: var(--color-text-dark);
     font-family: var(--main-font-name-it);
   }
+
+  &.inline {
+    position: static;
+    margin: auto;
+    padding: 8px 0;
+
+    .public-loading-icon {
+      width: 72px;
+      height: 72px;
+    }
+  }
 }

--- a/src/scss/profileView.scss
+++ b/src/scss/profileView.scss
@@ -257,3 +257,32 @@
     }
   }
 }
+
+// Full-page public loading: the round mark spinning, like the auth screen.
+.public-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+
+  .public-loading-icon {
+    background-image: url(../assets/icons/icon-256.png);
+    background-color: var(--color-base);
+    border-radius: 50%;
+    background-size: contain;
+    width: 96px;
+    height: 96px;
+    animation: rotate 1s infinite;
+  }
+
+  .public-loading-label {
+    color: var(--color-text-dark);
+    font-family: var(--main-font-name-it);
+  }
+}

--- a/src/scss/topNav.scss
+++ b/src/scss/topNav.scss
@@ -201,11 +201,19 @@
   }
 
   // The tier glyphs are drawn on a square 24 viewBox and fill the medallion,
-  // so they take the whole face and no nudge.
-  &[class*="tier-"] svg {
-    width: 100%;
-    height: 100%;
-    margin-left: 0;
+  // so they take the whole face and no nudge. The medallion itself runs
+  // bigger than the bar is tall — the negative margins let it overflow a
+  // little above and below without growing the top bar.
+  &[class*="tier-"] {
+    width: 32px;
+    height: 32px;
+    margin: -5px 8px;
+
+    svg {
+      width: 100%;
+      height: 100%;
+      margin-left: 0;
+    }
   }
 
   &:hover {

--- a/src/utils/getEventFormat.ts
+++ b/src/utils/getEventFormat.ts
@@ -1,0 +1,26 @@
+import isLimitedEventId from "./isLimitedEventId";
+
+/**
+ * Coarse format bucket for an event id, for "formats played" summaries.
+ * Order matters: an id like Play_Brawl_Historic is Brawl, not Historic, and
+ * Timeless_Ladder is Timeless, not Standard.
+ */
+export default function getEventFormat(eventId: string): string {
+  if (isLimitedEventId(eventId)) return "Limited";
+  const id = eventId.toLowerCase();
+  if (id.includes("brawl")) return "Brawl";
+  if (id.includes("alchemy")) return "Alchemy";
+  if (id.includes("timeless")) return "Timeless";
+  if (id.includes("historic")) return "Historic";
+  if (id.includes("explorer")) return "Explorer";
+  if (id.includes("pauper")) return "Pauper";
+  if (
+    id.includes("standard") ||
+    id.includes("constructed") ||
+    id.includes("ladder") ||
+    id.includes("play")
+  ) {
+    return "Standard";
+  }
+  return "Other";
+}

--- a/src/utils/safeDecodeURIComponent.ts
+++ b/src/utils/safeDecodeURIComponent.ts
@@ -1,0 +1,11 @@
+/**
+ * decodeURIComponent that survives malformed percent escapes — a hand-typed
+ * public URL must show "not found", not crash the view.
+ */
+export default function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/supabase/migrations/20260812210002_get_player_profile.sql
+++ b/supabase/migrations/20260812210002_get_player_profile.sql
@@ -1,0 +1,79 @@
+-- Public player profile, for the in-app profile screen. Security definer so
+-- it can read past per-user RLS, but it exposes only public fields and
+-- resolves to nothing for private-mode profiles — same stance as
+-- get_latest_ranks / get_public_profiles.
+--
+-- Looked up by arena persona id (what every rank feed row carries) or by
+-- username. The target user's privacy is checked from their profile row,
+-- with "no profile row" counting as visible, matching the public feed.
+
+create or replace function public.get_player_profile(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    -- An arena_id can be claimed by several logins; resolve to the one who
+    -- used it most recently. If that person is private the whole lookup
+    -- resolves to nothing — it does not fall through to older claimants.
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null and lower(p.username) = lower(p_username)
+    limit 1
+  )
+  select jsonb_build_object(
+    'username', p.username,
+    'avatar_url', p.avatar_url,
+    'supporter_tier', coalesce(p.supporter_tier, 0),
+    'background', p.background,
+    'member_since', p.created_at,
+    'accounts', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'arena_id', a.arena_id,
+            -- An arena_id can be claimed by several logins and the in-game
+            -- name is written sparsely, so take the freshest one any of the
+            -- claims has recorded.
+            'display_name', coalesce(a.display_name, (
+              select a3.display_name
+              from arena_accounts a3
+              where a3.arena_id = a.arena_id
+                and a3.display_name is not null
+              order by a3.last_seen_at desc
+              limit 1
+            )),
+            'constructed', r.constructed,
+            'limited', r.limited,
+            'ranks_updated_at', r.updated_at
+          )
+          order by a.last_seen_at desc
+        ),
+        '[]'::jsonb
+      )
+      from arena_accounts a
+      left join arena_ranks r
+        on r.user_id = a.user_id and r.arena_id = a.arena_id
+      where a.user_id = t.user_id
+    )
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+grant execute on function public.get_player_profile(text, text)
+  to anon, authenticated;

--- a/supabase/migrations/20260812214052_profile_visible_account_and_matches.sql
+++ b/supabase/migrations/20260812214052_profile_visible_account_and_matches.sql
@@ -1,0 +1,186 @@
+-- Public profiles show a single Arena account, not every id the user has
+-- ever played — accounts leak into existence unintentionally (a friend's
+-- login, an abandoned alt) and would just sit there empty. By default the
+-- most recently played account is shown; the owner can pin a specific one
+-- from Settings via profiles.visible_arena_id.
+--
+-- Also adds get_player_matches: the public recent-match list for that same
+-- account. Everyone can read the last 5; callers whose entitlement is
+-- Standard tier or higher can page through the full history. Responses never
+-- include arena ids or opponent names.
+
+alter table public.profiles
+  add column if not exists visible_arena_id text;
+
+create or replace function public.get_player_profile(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    -- An arena_id can be claimed by several logins; resolve to the one who
+    -- used it most recently. If that person is private the whole lookup
+    -- resolves to nothing — it does not fall through to older claimants.
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null and lower(p.username) = lower(p_username)
+    limit 1
+  ),
+  -- The single account this profile exposes: the pinned one when set and
+  -- still owned, otherwise the most recently played.
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'username', p.username,
+    'avatar_url', p.avatar_url,
+    'supporter_tier', coalesce(p.supporter_tier, 0),
+    'background', p.background,
+    'member_since', p.created_at,
+    'account', (
+      select jsonb_build_object(
+        -- The in-game name is written sparsely and the same arena_id can be
+        -- claimed by several logins, so take the freshest name any claim has.
+        'display_name', coalesce(a.display_name, (
+          select a3.display_name
+          from arena_accounts a3
+          where a3.arena_id = a.arena_id
+            and a3.display_name is not null
+          order by a3.last_seen_at desc
+          limit 1
+        )),
+        'constructed', r.constructed,
+        'limited', r.limited,
+        'ranks_updated_at', r.updated_at
+      )
+      from arena_accounts a
+      left join arena_ranks r
+        on r.user_id = a.user_id and r.arena_id = a.arena_id
+      join visible v on a.user_id = v.user_id and a.arena_id = v.arena_id
+    ),
+    'format_counts', (
+      select coalesce(jsonb_object_agg(x.event_id, x.n), '{}'::jsonb)
+      from (
+        select m.event_id, count(*) as n
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        group by m.event_id
+      ) x
+    )
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_player_matches(
+  p_arena_id text default null,
+  p_username text default null,
+  p_limit integer default 5,
+  p_offset integer default 0
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null and lower(p.username) = lower(p_username)
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  -- Entitlements are the server-written pledge record; Standard tier (2) and
+  -- up may page through the whole history, everyone else gets the last 5.
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  ),
+  bounds as (
+    select
+      case when w.full_access
+        then least(greatest(coalesce(p_limit, 5), 1), 50)
+        else least(greatest(coalesce(p_limit, 5), 1), 5)
+      end as lim,
+      case when w.full_access then greatest(coalesce(p_offset, 0), 0) else 0 end as off,
+      w.full_access
+    from viewer w
+  )
+  select jsonb_build_object(
+    'matches', coalesce((
+      select jsonb_agg(row_json)
+      from (
+        select jsonb_build_object(
+          'event_id', m.event_id,
+          'played_at', m.played_at,
+          'deck_name', m.internal_match -> 'playerDeck' ->> 'name',
+          'player_deck_colors', m.player_deck_colors,
+          'opp_deck_colors', m.opp_deck_colors,
+          'player_wins', m.player_wins,
+          'player_losses', m.player_losses,
+          'duration', m.duration
+        ) as row_json
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        order by m.played_at desc
+        limit (select lim from bounds)
+        offset (select off from bounds)
+      ) page
+    ), '[]'::jsonb),
+    'total', (
+      select count(*)
+      from matches m
+      join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+    ),
+    'full_access', (select full_access from bounds)
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+grant execute on function public.get_player_matches(text, text, integer, integer)
+  to anon, authenticated;

--- a/supabase/migrations/20260812215847_public_match_details.sql
+++ b/supabase/migrations/20260812215847_public_match_details.sql
@@ -1,0 +1,197 @@
+-- Profile match rows get what the History-tab rows show (deck tile, colors,
+-- opponent name, both players' ranks) plus the match id so a row can open a
+-- public match page. get_public_match serves that page: the played deck,
+-- result, event and ranks — never arena ids, action logs or game telemetry.
+
+create or replace function public.get_player_matches(
+  p_arena_id text default null,
+  p_username text default null,
+  p_limit integer default 5,
+  p_offset integer default 0
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null and lower(p.username) = lower(p_username)
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  -- Entitlements are the server-written pledge record; Standard tier (2) and
+  -- up may page through the whole history, everyone else gets the last 5.
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  ),
+  bounds as (
+    select
+      case when w.full_access
+        then least(greatest(coalesce(p_limit, 5), 1), 50)
+        else least(greatest(coalesce(p_limit, 5), 1), 5)
+      end as lim,
+      case when w.full_access then greatest(coalesce(p_offset, 0), 0) else 0 end as off,
+      w.full_access
+    from viewer w
+  )
+  select jsonb_build_object(
+    'matches', coalesce((
+      select jsonb_agg(row_json)
+      from (
+        select jsonb_build_object(
+          'match_id', m.match_id,
+          'event_id', m.event_id,
+          'played_at', m.played_at,
+          'deck_name', m.internal_match -> 'playerDeck' ->> 'name',
+          'deck_tile_id', m.internal_match -> 'playerDeck' -> 'deckTileId',
+          -- Draft decks carry the stock tile; ship their card ids so the
+          -- client can borrow a mythic/rare for art, like the History tab.
+          'fallback_ids', case
+            when coalesce((m.internal_match -> 'playerDeck' ->> 'deckTileId')::numeric, 0)
+              in (0, 67003)
+            then (
+              select jsonb_agg(distinct c -> 'id')
+              from jsonb_array_elements(m.internal_match -> 'playerDeck' -> 'mainDeck') c
+            )
+            else null
+          end,
+          'opp_name', m.internal_match -> 'opponent' ->> 'name',
+          'player_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'player' ->> 'rank',
+            'tier', m.internal_match -> 'player' -> 'tier',
+            'step', m.internal_match -> 'player' -> 'step',
+            'percentile', m.internal_match -> 'player' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+          ),
+          'opp_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'opponent' ->> 'rank',
+            'tier', m.internal_match -> 'opponent' -> 'tier',
+            'step', m.internal_match -> 'opponent' -> 'step',
+            'percentile', m.internal_match -> 'opponent' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+          ),
+          'player_deck_colors', m.player_deck_colors,
+          'opp_deck_colors', m.opp_deck_colors,
+          'player_wins', m.player_wins,
+          'player_losses', m.player_losses,
+          'duration', m.duration
+        ) as row_json
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        order by m.played_at desc
+        limit (select lim from bounds)
+        offset (select off from bounds)
+      ) page
+    ), '[]'::jsonb),
+    'total', (
+      select count(*)
+      from matches m
+      join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+    ),
+    'full_access', (select full_access from bounds)
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+-- The public view of one match: enough to show the played deck, the
+-- opponent and the result. Scoped to the profile's visible account and gated
+-- on the same privacy flag; match ids only circulate via get_player_matches,
+-- which is what limits who can discover them.
+create or replace function public.get_public_match(
+  p_match_id text,
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null and lower(p.username) = lower(p_username)
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'match_id', m.match_id,
+    'event_id', m.event_id,
+    'played_at', m.played_at,
+    'duration', m.duration,
+    'best_of', m.internal_match -> 'bestOf',
+    'player_wins', m.player_wins,
+    'player_losses', m.player_losses,
+    'player_deck', m.internal_match -> 'playerDeck',
+    'opp_deck_colors', m.opp_deck_colors,
+    'opp_name', m.internal_match -> 'opponent' ->> 'name',
+    'player_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'player' ->> 'rank',
+      'tier', m.internal_match -> 'player' -> 'tier',
+      'step', m.internal_match -> 'player' -> 'step',
+      'percentile', m.internal_match -> 'player' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+    ),
+    'opp_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'opponent' ->> 'rank',
+      'tier', m.internal_match -> 'opponent' -> 'tier',
+      'step', m.internal_match -> 'opponent' -> 'step',
+      'percentile', m.internal_match -> 'opponent' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+    )
+  )
+  from matches m
+  join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+  join target t on true
+  left join profiles p on p.id = t.user_id
+  where m.match_id = p_match_id
+    and coalesce(p.is_private, false) = false;
+$$;
+
+grant execute on function public.get_public_match(text, text, text)
+  to anon, authenticated;

--- a/supabase/migrations/20260812221540_profile_display_names.sql
+++ b/supabase/migrations/20260812221540_profile_display_names.sql
@@ -1,0 +1,352 @@
+-- Signup keeps the pretty username the user typed ("Manwë") in the auth
+-- metadata and derives a lowercase ASCII login id ("manwe") from it; the
+-- profiles trigger only ever copied the login id, so every public surface
+-- showed the folded name. Store the pretty one on the profile, backfill it
+-- from auth metadata, and make the public reads prefer it.
+--
+-- Also: profile match lists and the public match page now carry the
+-- opponent's in-game name, and profile lookups by name accept the display
+-- name as well as the login id.
+
+alter table public.profiles
+  add column if not exists display_name text;
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, username, display_name)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'username', 'user-' || substr(new.id::text, 1, 8)),
+    new.raw_user_meta_data->>'display_name'
+  );
+  return new;
+end;
+$$;
+
+update public.profiles p
+set display_name = u.raw_user_meta_data ->> 'display_name'
+from auth.users u
+where u.id = p.id
+  and p.display_name is null
+  and u.raw_user_meta_data ->> 'display_name' is not null;
+
+create or replace function public.get_latest_ranks(p_limit integer default 100)
+returns table(
+  arena_id text,
+  display_name text,
+  username text,
+  avatar_url text,
+  constructed jsonb,
+  limited jsonb,
+  updated_at timestamp with time zone
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  -- One row per arena persona: latest non-bogus rank, resolved to a single
+  -- account (an arena_id can be claimed by more than one login), private
+  -- profiles excluded. "Spark" is the placeholder a failed rank read wrote.
+  select s.arena_id, s.display_name, s.username, s.avatar_url,
+         s.constructed, s.limited, s.updated_at
+  from (
+    select distinct on (r.arena_id)
+      r.arena_id, a.display_name,
+      coalesce(p.display_name, p.username) as username,
+      p.avatar_url,
+      r.constructed, r.limited, r.updated_at
+    from arena_ranks r
+    join lateral (
+      select a2.display_name, a2.user_id
+      from arena_accounts a2
+      where a2.arena_id = r.arena_id
+      order by a2.last_seen_at desc
+      limit 1
+    ) a on true
+    left join profiles p on p.id = a.user_id
+    where coalesce(p.is_private, false) = false
+      and coalesce(r.constructed->>'class', '') <> 'Spark'
+    order by r.arena_id, r.updated_at desc
+  ) s
+  order by s.updated_at desc
+  limit greatest(1, least(p_limit, 300))
+$$;
+
+create or replace function public.get_player_profile(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    -- An arena_id can be claimed by several logins; resolve to the one who
+    -- used it most recently. If that person is private the whole lookup
+    -- resolves to nothing — it does not fall through to older claimants.
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  -- The single account this profile exposes: the pinned one when set and
+  -- still owned, otherwise the most recently played.
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'username', coalesce(p.display_name, p.username),
+    'avatar_url', p.avatar_url,
+    'supporter_tier', coalesce(p.supporter_tier, 0),
+    'background', p.background,
+    'member_since', p.created_at,
+    'account', (
+      select jsonb_build_object(
+        -- The in-game name is written sparsely and the same arena_id can be
+        -- claimed by several logins, so take the freshest name any claim has.
+        'display_name', coalesce(a.display_name, (
+          select a3.display_name
+          from arena_accounts a3
+          where a3.arena_id = a.arena_id
+            and a3.display_name is not null
+          order by a3.last_seen_at desc
+          limit 1
+        )),
+        'constructed', r.constructed,
+        'limited', r.limited,
+        'ranks_updated_at', r.updated_at
+      )
+      from arena_accounts a
+      left join arena_ranks r
+        on r.user_id = a.user_id and r.arena_id = a.arena_id
+      join visible v on a.user_id = v.user_id and a.arena_id = v.arena_id
+    ),
+    'format_counts', (
+      select coalesce(jsonb_object_agg(x.event_id, x.n), '{}'::jsonb)
+      from (
+        select m.event_id, count(*) as n
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        group by m.event_id
+      ) x
+    )
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_player_matches(
+  p_arena_id text default null,
+  p_username text default null,
+  p_limit integer default 5,
+  p_offset integer default 0
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  -- Entitlements are the server-written pledge record; Standard tier (2) and
+  -- up may page through the whole history, everyone else gets the last 5.
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  ),
+  bounds as (
+    select
+      case when w.full_access
+        then least(greatest(coalesce(p_limit, 5), 1), 50)
+        else least(greatest(coalesce(p_limit, 5), 1), 5)
+      end as lim,
+      case when w.full_access then greatest(coalesce(p_offset, 0), 0) else 0 end as off,
+      w.full_access
+    from viewer w
+  )
+  select jsonb_build_object(
+    'matches', coalesce((
+      select jsonb_agg(row_json)
+      from (
+        select jsonb_build_object(
+          'match_id', m.match_id,
+          'event_id', m.event_id,
+          'played_at', m.played_at,
+          'deck_name', m.internal_match -> 'playerDeck' ->> 'name',
+          'deck_tile_id', m.internal_match -> 'playerDeck' -> 'deckTileId',
+          -- Draft decks carry the stock tile; ship their card ids so the
+          -- client can borrow a mythic/rare for art, like the History tab.
+          'fallback_ids', case
+            when coalesce((m.internal_match -> 'playerDeck' ->> 'deckTileId')::numeric, 0)
+              in (0, 67003)
+            then (
+              select jsonb_agg(distinct c -> 'id')
+              from jsonb_array_elements(m.internal_match -> 'playerDeck' -> 'mainDeck') c
+            )
+            else null
+          end,
+          'opp_name', m.internal_match -> 'opponent' ->> 'name',
+          'player_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'player' ->> 'rank',
+            'tier', m.internal_match -> 'player' -> 'tier',
+            'step', m.internal_match -> 'player' -> 'step',
+            'percentile', m.internal_match -> 'player' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+          ),
+          'opp_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'opponent' ->> 'rank',
+            'tier', m.internal_match -> 'opponent' -> 'tier',
+            'step', m.internal_match -> 'opponent' -> 'step',
+            'percentile', m.internal_match -> 'opponent' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+          ),
+          'player_deck_colors', m.player_deck_colors,
+          'opp_deck_colors', m.opp_deck_colors,
+          'player_wins', m.player_wins,
+          'player_losses', m.player_losses,
+          'duration', m.duration
+        ) as row_json
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        order by m.played_at desc
+        limit (select lim from bounds)
+        offset (select off from bounds)
+      ) page
+    ), '[]'::jsonb),
+    'total', (
+      select count(*)
+      from matches m
+      join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+    ),
+    'full_access', (select full_access from bounds)
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_public_match(
+  p_match_id text,
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'match_id', m.match_id,
+    'event_id', m.event_id,
+    'played_at', m.played_at,
+    'duration', m.duration,
+    'best_of', m.internal_match -> 'bestOf',
+    'player_wins', m.player_wins,
+    'player_losses', m.player_losses,
+    'player_deck', m.internal_match -> 'playerDeck',
+    'action_log', m.internal_match -> 'actionLog',
+    'opp_deck_colors', m.opp_deck_colors,
+    'opp_name', m.internal_match -> 'opponent' ->> 'name',
+    'player_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'player' ->> 'rank',
+      'tier', m.internal_match -> 'player' -> 'tier',
+      'step', m.internal_match -> 'player' -> 'step',
+      'percentile', m.internal_match -> 'player' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+    ),
+    'opp_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'opponent' ->> 'rank',
+      'tier', m.internal_match -> 'opponent' -> 'tier',
+      'step', m.internal_match -> 'opponent' -> 'step',
+      'percentile', m.internal_match -> 'opponent' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+    )
+  )
+  from matches m
+  join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+  join target t on true
+  left join profiles p on p.id = t.user_id
+  where m.match_id = p_match_id
+    and coalesce(p.is_private, false) = false;
+$$;

--- a/supabase/migrations/20260812224158_profile_decks_and_recent_form.sql
+++ b/supabase/migrations/20260812224158_profile_decks_and_recent_form.sql
@@ -1,0 +1,361 @@
+-- Profile polish round: the banner's win-loss records now cover the last 30
+-- days of matches (season totals made the rank records misleading right
+-- after a season reset), the profile carries the visible account's
+-- last-seen timestamp, match lookups can be filtered to one deck, and a new
+-- patron-gated get_player_decks aggregates the player's decks with their
+-- records so profiles can show a deck list like the Home tab's.
+
+create or replace function public.get_player_profile(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    -- An arena_id can be claimed by several logins; resolve to the one who
+    -- used it most recently. If that person is private the whole lookup
+    -- resolves to nothing — it does not fall through to older claimants.
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  -- The single account this profile exposes: the pinned one when set and
+  -- still owned, otherwise the most recently played.
+  visible as (
+    select a.user_id, a.arena_id, a.last_seen_at
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'username', coalesce(p.display_name, p.username),
+    'avatar_url', p.avatar_url,
+    'supporter_tier', coalesce(p.supporter_tier, 0),
+    'background', p.background,
+    'member_since', p.created_at,
+    'last_seen', (select v.last_seen_at from visible v),
+    'account', (
+      select jsonb_build_object(
+        -- The in-game name is written sparsely and the same arena_id can be
+        -- claimed by several logins, so take the freshest name any claim has.
+        'display_name', coalesce(a.display_name, (
+          select a3.display_name
+          from arena_accounts a3
+          where a3.arena_id = a.arena_id
+            and a3.display_name is not null
+          order by a3.last_seen_at desc
+          limit 1
+        )),
+        'constructed', r.constructed,
+        'limited', r.limited,
+        'ranks_updated_at', r.updated_at
+      )
+      from arena_accounts a
+      left join arena_ranks r
+        on r.user_id = a.user_id and r.arena_id = a.arena_id
+      join visible v on a.user_id = v.user_id and a.arena_id = v.arena_id
+    ),
+    -- Match records over a rolling month, split by format side. The rank's
+    -- own season totals reset with every season, so they say little right
+    -- after a rollover.
+    'recent_30d', (
+      select jsonb_build_object(
+        'constructed', jsonb_build_object(
+          'wins',   count(*) filter (where not x.lim and x.won),
+          'losses', count(*) filter (where not x.lim and not x.won)
+        ),
+        'limited', jsonb_build_object(
+          'wins',   count(*) filter (where x.lim and x.won),
+          'losses', count(*) filter (where x.lim and not x.won)
+        )
+      )
+      from (
+        select (m.event_id ~* 'draft|sealed') as lim,
+               (m.player_wins > m.player_losses) as won
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        where m.played_at > now() - interval '30 days'
+      ) x
+    ),
+    'format_counts', (
+      select coalesce(jsonb_object_agg(x.event_id, x.n), '{}'::jsonb)
+      from (
+        select m.event_id, count(*) as n
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        group by m.event_id
+      ) x
+    )
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+-- Adding p_deck_id changes the signature; drop the old overloads so
+-- PostgREST has exactly one candidate.
+drop function if exists public.get_player_matches(text, text, integer, integer);
+drop function if exists public.get_player_matches(text, text, integer, integer, text);
+
+create or replace function public.get_player_matches(
+  p_arena_id text default null,
+  p_username text default null,
+  p_limit integer default 5,
+  p_offset integer default 0,
+  p_deck_id text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  -- Entitlements are the server-written pledge record; Standard tier (2) and
+  -- up may page through the whole history, everyone else gets the last 5.
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  ),
+  bounds as (
+    select
+      case when w.full_access
+        then least(greatest(coalesce(p_limit, 5), 1), 50)
+        else least(greatest(coalesce(p_limit, 5), 1), 5)
+      end as lim,
+      case when w.full_access then greatest(coalesce(p_offset, 0), 0) else 0 end as off,
+      w.full_access
+    from viewer w
+  )
+  select jsonb_build_object(
+    'matches', coalesce((
+      select jsonb_agg(row_json)
+      from (
+        select jsonb_build_object(
+          'match_id', m.match_id,
+          'event_id', m.event_id,
+          'played_at', m.played_at,
+          'deck_name', m.internal_match -> 'playerDeck' ->> 'name',
+          'deck_tile_id', m.internal_match -> 'playerDeck' -> 'deckTileId',
+          -- Draft decks carry the stock tile; ship their card ids so the
+          -- client can borrow a mythic/rare for art, like the History tab.
+          'fallback_ids', case
+            when coalesce((m.internal_match -> 'playerDeck' ->> 'deckTileId')::numeric, 0)
+              in (0, 67003)
+            then (
+              select jsonb_agg(distinct c -> 'id')
+              from jsonb_array_elements(m.internal_match -> 'playerDeck' -> 'mainDeck') c
+            )
+            else null
+          end,
+          'opp_name', m.internal_match -> 'opponent' ->> 'name',
+          'player_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'player' ->> 'rank',
+            'tier', m.internal_match -> 'player' -> 'tier',
+            'step', m.internal_match -> 'player' -> 'step',
+            'percentile', m.internal_match -> 'player' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+          ),
+          'opp_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'opponent' ->> 'rank',
+            'tier', m.internal_match -> 'opponent' -> 'tier',
+            'step', m.internal_match -> 'opponent' -> 'step',
+            'percentile', m.internal_match -> 'opponent' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+          ),
+          'player_deck_colors', m.player_deck_colors,
+          'opp_deck_colors', m.opp_deck_colors,
+          'player_wins', m.player_wins,
+          'player_losses', m.player_losses,
+          'duration', m.duration
+        ) as row_json
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        where p_deck_id is null
+          or coalesce(m.player_deck_id, m.player_deck_hash) = p_deck_id
+        order by m.played_at desc
+        limit (select lim from bounds)
+        offset (select off from bounds)
+      ) page
+    ), '[]'::jsonb),
+    'total', (
+      select count(*)
+      from matches m
+      join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+      where p_deck_id is null
+        or coalesce(m.player_deck_id, m.player_deck_hash) = p_deck_id
+    ),
+    'full_access', (select full_access from bounds)
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+grant execute on function public.get_player_matches(text, text, integer, integer, text)
+  to anon, authenticated;
+
+
+-- The player's decks with their records, aggregated from their uploaded
+-- matches — a Standard-tier perk, like browsing the full history. Non-patron
+-- callers get an empty list and full_access=false so the client can show
+-- the upgrade pitch instead.
+create or replace function public.get_player_decks(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    select p.id
+    from profiles p
+    where p_username is not null
+      and (lower(p.username) = lower(p_username)
+        or lower(p.display_name) = lower(p_username))
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  )
+  select jsonb_build_object(
+    'full_access', (select full_access from viewer),
+    'decks', case when (select full_access from viewer) then coalesce((
+      select jsonb_agg(deck_json order by score desc)
+      from (
+        select g.score,
+               jsonb_build_object(
+                 'id', g.deck_key,
+                 'games', g.games,
+                 'wins', g.wins,
+                 'last_played', g.last_played,
+                 -- The latest version's snapshot; the record above spans
+                 -- every version of the deck.
+                 'deck', lm.internal_match -> 'playerDeck'
+               ) as deck_json
+        from (
+          -- One row per DECK, not per version: sideboard tweaks change the
+          -- hash but keep the Arena deck id, so group on the id (hash only
+          -- for old rows that never stored one). Top 5 by the Wilson lower
+          -- bound (z=1.96) of the match winrate — the same score the Home
+          -- tab ranks top decks with, so a single good night cannot outrank
+          -- a deck with forty games behind it.
+          select counts.deck_key, counts.games, counts.wins, counts.last_played,
+                 ((counts.wins::numeric / counts.games)
+                   + 1.9208 / counts.games
+                   - 1.96 * sqrt(((counts.wins::numeric / counts.games)
+                       * (1 - counts.wins::numeric / counts.games)
+                       + 0.9604 / counts.games) / counts.games))
+                 / (1 + 3.8416 / counts.games) as score
+          from (
+            -- nullif: a failed parse can store an EMPTY deck id/hash, which
+            -- would aggregate into a nameless, cardless "deck".
+            select nullif(coalesce(m.player_deck_id, m.player_deck_hash), '') as deck_key,
+                   count(*) as games,
+                   count(*) filter (where m.player_wins > m.player_losses) as wins,
+                   max(m.played_at) as last_played
+            from matches m
+            join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+            where nullif(coalesce(m.player_deck_id, m.player_deck_hash), '') is not null
+            group by nullif(coalesce(m.player_deck_id, m.player_deck_hash), '')
+          ) counts
+          order by score desc
+          limit 5
+        ) g
+        join lateral (
+          select m2.internal_match
+          from matches m2
+          join visible v2 on m2.user_id = v2.user_id and m2.arena_id = v2.arena_id
+          where coalesce(m2.player_deck_id, m2.player_deck_hash) = g.deck_key
+          order by m2.played_at desc
+          limit 1
+        ) lm on true
+        -- A snapshot with no cards cannot be shown or opened; skip it.
+        where jsonb_array_length(
+          coalesce(lm.internal_match -> 'playerDeck' -> 'mainDeck', '[]'::jsonb)
+        ) > 0
+      ) rows_
+    ), '[]'::jsonb) else '[]'::jsonb end
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+grant execute on function public.get_player_decks(text, text)
+  to anon, authenticated;

--- a/supabase/migrations/20260812231421_shared_deck_profile_link.sql
+++ b/supabase/migrations/20260812231421_shared_deck_profile_link.sql
@@ -1,0 +1,51 @@
+-- The shared-deck page links back to the owner's profile and shows the
+-- deck's recent matches, so the payload now carries the pretty display name
+-- and the Arena deck id (both withheld for private-mode owners, whose
+-- profile and matches resolve to nothing anyway).
+
+create or replace function public.get_shared_deck(p_share_id text)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select jsonb_build_object(
+    'deck', sd.deck,
+    'updated_at', sd.updated_at,
+    'deck_id', case
+      when coalesce(p.is_private, false) then null
+      else sd.deck_id
+    end,
+    'owner', case
+      when coalesce(p.is_private, false) then jsonb_build_object(
+        'username', null,
+        'avatar_url', null,
+        'supporter_tier', coalesce(p.supporter_tier, 0)
+      )
+      else jsonb_build_object(
+        'username', coalesce(p.display_name, p.username),
+        'avatar_url', p.avatar_url,
+        'supporter_tier', coalesce(p.supporter_tier, 0)
+      )
+    end,
+    'winrate', case
+      when sd.include_winrate then (
+        select jsonb_build_object(
+          'wins', count(*) filter (
+            where coalesce(m.player_wins, 0) > coalesce(m.player_losses, 0)
+          ),
+          'losses', count(*) filter (
+            where coalesce(m.player_wins, 0) <= coalesce(m.player_losses, 0)
+          )
+        )
+        from matches m
+        where m.user_id = sd.user_id and m.player_deck_id = sd.deck_id
+      )
+      else null
+    end
+  )
+  from shared_decks sd
+  left join profiles p on p.id = sd.user_id
+  where sd.share_id = p_share_id;
+$$;

--- a/supabase/migrations/20260813030031_profile_review_fixes.sql
+++ b/supabase/migrations/20260813030031_profile_review_fixes.sql
@@ -1,0 +1,479 @@
+-- Review fixes for the public profile RPCs:
+-- - name lookups resolve exact username matches before anyone's display
+--   name (display names are not unique — an imposter could otherwise
+--   capture a profile URL), with a deterministic tiebreak;
+-- - matches tombstoned in deleted_matches (deleted locally, purge pending)
+--   are excluded from every public read;
+-- - a null event_id no longer sinks the whole profile call;
+-- - match pages order with nulls last and a unique tiebreaker so
+--   pagination cannot duplicate or drop rows.
+
+create or replace function public.get_player_profile(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    -- An arena_id can be claimed by several logins; resolve to the one who
+    -- used it most recently. If that person is private the whole lookup
+    -- resolves to nothing — it does not fall through to older claimants.
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    -- Usernames are unique; display names are not. An exact username match
+    -- must win over anyone else's display name (impersonation), and among
+    -- display-name matches the oldest account wins, deterministically.
+    select id from (
+      select p.id
+      from profiles p
+      where p_username is not null
+        and (lower(p.username) = lower(p_username)
+          or lower(p.display_name) = lower(p_username))
+      order by (lower(p.username) = lower(p_username)) desc, p.created_at asc
+      limit 1
+    ) by_name
+    limit 1
+  ),
+  -- The single account this profile exposes: the pinned one when set and
+  -- still owned, otherwise the most recently played.
+  visible as (
+    select a.user_id, a.arena_id, a.last_seen_at
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'username', coalesce(p.display_name, p.username),
+    'avatar_url', p.avatar_url,
+    'supporter_tier', coalesce(p.supporter_tier, 0),
+    'background', p.background,
+    'member_since', p.created_at,
+    'last_seen', (select v.last_seen_at from visible v),
+    'account', (
+      select jsonb_build_object(
+        -- The in-game name is written sparsely and the same arena_id can be
+        -- claimed by several logins, so take the freshest name any claim has.
+        'display_name', coalesce(a.display_name, (
+          select a3.display_name
+          from arena_accounts a3
+          where a3.arena_id = a.arena_id
+            and a3.display_name is not null
+          order by a3.last_seen_at desc
+          limit 1
+        )),
+        'constructed', r.constructed,
+        'limited', r.limited,
+        'ranks_updated_at', r.updated_at
+      )
+      from arena_accounts a
+      left join arena_ranks r
+        on r.user_id = a.user_id and r.arena_id = a.arena_id
+      join visible v on a.user_id = v.user_id and a.arena_id = v.arena_id
+    ),
+    -- Match records over a rolling month, split by format side. The rank's
+    -- own season totals reset with every season, so they say little right
+    -- after a rollover.
+    'recent_30d', (
+      select jsonb_build_object(
+        'constructed', jsonb_build_object(
+          'wins',   count(*) filter (where not x.lim and x.won),
+          'losses', count(*) filter (where not x.lim and not x.won)
+        ),
+        'limited', jsonb_build_object(
+          'wins',   count(*) filter (where x.lim and x.won),
+          'losses', count(*) filter (where x.lim and not x.won)
+        )
+      )
+      from (
+        select (m.event_id ~* 'draft|sealed') as lim,
+               (m.player_wins > m.player_losses) as won
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        where m.played_at > now() - interval '30 days'
+          and not exists (
+            select 1 from deleted_matches dm
+            where dm.user_id = m.user_id and dm.match_id = m.match_id
+          )
+      ) x
+    ),
+    'format_counts', (
+      select coalesce(jsonb_object_agg(x.event_id, x.n), '{}'::jsonb)
+      from (
+        select m.event_id, count(*) as n
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        -- a null event_id would sink jsonb_object_agg (and the whole call)
+        where m.event_id is not null
+          and not exists (
+            select 1 from deleted_matches dm
+            where dm.user_id = m.user_id and dm.match_id = m.match_id
+          )
+        group by m.event_id
+      ) x
+    )
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_player_matches(
+  p_arena_id text default null,
+  p_username text default null,
+  p_limit integer default 5,
+  p_offset integer default 0,
+  p_deck_id text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    -- Usernames are unique; display names are not. An exact username match
+    -- must win over anyone else's display name (impersonation), and among
+    -- display-name matches the oldest account wins, deterministically.
+    select id from (
+      select p.id
+      from profiles p
+      where p_username is not null
+        and (lower(p.username) = lower(p_username)
+          or lower(p.display_name) = lower(p_username))
+      order by (lower(p.username) = lower(p_username)) desc, p.created_at asc
+      limit 1
+    ) by_name
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  -- Entitlements are the server-written pledge record; Standard tier (2) and
+  -- up may page through the whole history, everyone else gets the last 5.
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  ),
+  bounds as (
+    select
+      case when w.full_access
+        then least(greatest(coalesce(p_limit, 5), 1), 50)
+        else least(greatest(coalesce(p_limit, 5), 1), 5)
+      end as lim,
+      case when w.full_access then greatest(coalesce(p_offset, 0), 0) else 0 end as off,
+      w.full_access
+    from viewer w
+  )
+  select jsonb_build_object(
+    'matches', coalesce((
+      select jsonb_agg(row_json)
+      from (
+        select jsonb_build_object(
+          'match_id', m.match_id,
+          'event_id', m.event_id,
+          'played_at', m.played_at,
+          'deck_name', m.internal_match -> 'playerDeck' ->> 'name',
+          'deck_tile_id', m.internal_match -> 'playerDeck' -> 'deckTileId',
+          -- Draft decks carry the stock tile; ship their card ids so the
+          -- client can borrow a mythic/rare for art, like the History tab.
+          'fallback_ids', case
+            when coalesce((m.internal_match -> 'playerDeck' ->> 'deckTileId')::numeric, 0)
+              in (0, 67003)
+            then (
+              select jsonb_agg(distinct c -> 'id')
+              from jsonb_array_elements(m.internal_match -> 'playerDeck' -> 'mainDeck') c
+            )
+            else null
+          end,
+          'opp_name', m.internal_match -> 'opponent' ->> 'name',
+          'player_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'player' ->> 'rank',
+            'tier', m.internal_match -> 'player' -> 'tier',
+            'step', m.internal_match -> 'player' -> 'step',
+            'percentile', m.internal_match -> 'player' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+          ),
+          'opp_rank', jsonb_build_object(
+            'rank', m.internal_match -> 'opponent' ->> 'rank',
+            'tier', m.internal_match -> 'opponent' -> 'tier',
+            'step', m.internal_match -> 'opponent' -> 'step',
+            'percentile', m.internal_match -> 'opponent' -> 'percentile',
+            'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+          ),
+          'player_deck_colors', m.player_deck_colors,
+          'opp_deck_colors', m.opp_deck_colors,
+          'player_wins', m.player_wins,
+          'player_losses', m.player_losses,
+          'duration', m.duration
+        ) as row_json
+        from matches m
+        join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+        where (p_deck_id is null
+            or coalesce(m.player_deck_id, m.player_deck_hash) = p_deck_id)
+          and not exists (
+            select 1 from deleted_matches dm
+            where dm.user_id = m.user_id and dm.match_id = m.match_id
+          )
+        -- nulls last + unique tiebreaker: a null played_at would float to
+        -- the top, and unstable order between pages duplicates rows
+        order by m.played_at desc nulls last, m.match_id
+        limit (select lim from bounds)
+        offset (select off from bounds)
+      ) page
+    ), '[]'::jsonb),
+    'total', (
+      select count(*)
+      from matches m
+      join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+      where (p_deck_id is null
+          or coalesce(m.player_deck_id, m.player_deck_hash) = p_deck_id)
+        and not exists (
+          select 1 from deleted_matches dm
+          where dm.user_id = m.user_id and dm.match_id = m.match_id
+        )
+    ),
+    'full_access', (select full_access from bounds)
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_player_decks(
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    -- Usernames are unique; display names are not. An exact username match
+    -- must win over anyone else's display name (impersonation), and among
+    -- display-name matches the oldest account wins, deterministically.
+    select id from (
+      select p.id
+      from profiles p
+      where p_username is not null
+        and (lower(p.username) = lower(p_username)
+          or lower(p.display_name) = lower(p_username))
+      order by (lower(p.username) = lower(p_username)) desc, p.created_at asc
+      limit 1
+    ) by_name
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  ),
+  viewer as (
+    select exists (
+      select 1
+      from entitlements e
+      where e.user_id = auth.uid()
+        and e.active
+        and e.tier >= 2
+        and (e.expires_at is null or e.expires_at > now())
+    ) as full_access
+  )
+  select jsonb_build_object(
+    'full_access', (select full_access from viewer),
+    'decks', case when (select full_access from viewer) then coalesce((
+      select jsonb_agg(deck_json order by score desc)
+      from (
+        select g.score,
+               jsonb_build_object(
+                 'id', g.deck_key,
+                 'games', g.games,
+                 'wins', g.wins,
+                 'last_played', g.last_played,
+                 -- The latest version's snapshot; the record above spans
+                 -- every version of the deck.
+                 'deck', lm.internal_match -> 'playerDeck'
+               ) as deck_json
+        from (
+          -- One row per DECK, not per version: sideboard tweaks change the
+          -- hash but keep the Arena deck id, so group on the id (hash only
+          -- for old rows that never stored one). Top 5 by the Wilson lower
+          -- bound (z=1.96) of the match winrate — the same score the Home
+          -- tab ranks top decks with, so a single good night cannot outrank
+          -- a deck with forty games behind it.
+          select counts.deck_key, counts.games, counts.wins, counts.last_played,
+                 ((counts.wins::numeric / counts.games)
+                   + 1.9208 / counts.games
+                   - 1.96 * sqrt(((counts.wins::numeric / counts.games)
+                       * (1 - counts.wins::numeric / counts.games)
+                       + 0.9604 / counts.games) / counts.games))
+                 / (1 + 3.8416 / counts.games) as score
+          from (
+            -- nullif: a failed parse can store an EMPTY deck id/hash, which
+            -- would aggregate into a nameless, cardless "deck".
+            select nullif(coalesce(m.player_deck_id, m.player_deck_hash), '') as deck_key,
+                   count(*) as games,
+                   count(*) filter (where m.player_wins > m.player_losses) as wins,
+                   max(m.played_at) as last_played
+            from matches m
+            join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+            where nullif(coalesce(m.player_deck_id, m.player_deck_hash), '') is not null
+              and not exists (
+                select 1 from deleted_matches dm
+                where dm.user_id = m.user_id and dm.match_id = m.match_id
+              )
+            group by nullif(coalesce(m.player_deck_id, m.player_deck_hash), '')
+          ) counts
+          order by score desc
+          limit 5
+        ) g
+        join lateral (
+          select m2.internal_match
+          from matches m2
+          join visible v2 on m2.user_id = v2.user_id and m2.arena_id = v2.arena_id
+          where coalesce(m2.player_deck_id, m2.player_deck_hash) = g.deck_key
+            and not exists (
+              select 1 from deleted_matches dm
+              where dm.user_id = m2.user_id and dm.match_id = m2.match_id
+            )
+          order by m2.played_at desc nulls last
+          limit 1
+        ) lm on true
+        -- A snapshot with no cards cannot be shown or opened; skip it.
+        where jsonb_array_length(
+          coalesce(lm.internal_match -> 'playerDeck' -> 'mainDeck', '[]'::jsonb)
+        ) > 0
+      ) rows_
+    ), '[]'::jsonb) else '[]'::jsonb end
+  )
+  from target t
+  left join profiles p on p.id = t.user_id
+  where coalesce(p.is_private, false) = false;
+$$;
+
+create or replace function public.get_public_match(
+  p_match_id text,
+  p_arena_id text default null,
+  p_username text default null
+)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  with target as (
+    select user_id from (
+      select a.user_id, a.last_seen_at
+      from arena_accounts a
+      where p_arena_id is not null and a.arena_id = p_arena_id
+      order by a.last_seen_at desc
+      limit 1
+    ) latest_claimant
+    union all
+    -- Usernames are unique; display names are not. An exact username match
+    -- must win over anyone else's display name (impersonation), and among
+    -- display-name matches the oldest account wins, deterministically.
+    select id from (
+      select p.id
+      from profiles p
+      where p_username is not null
+        and (lower(p.username) = lower(p_username)
+          or lower(p.display_name) = lower(p_username))
+      order by (lower(p.username) = lower(p_username)) desc, p.created_at asc
+      limit 1
+    ) by_name
+    limit 1
+  ),
+  visible as (
+    select a.user_id, a.arena_id
+    from arena_accounts a
+    join target t on a.user_id = t.user_id
+    left join profiles pp on pp.id = t.user_id
+    order by (a.arena_id = pp.visible_arena_id) desc nulls last,
+             a.last_seen_at desc
+    limit 1
+  )
+  select jsonb_build_object(
+    'match_id', m.match_id,
+    'event_id', m.event_id,
+    'played_at', m.played_at,
+    'duration', m.duration,
+    'best_of', m.internal_match -> 'bestOf',
+    'player_wins', m.player_wins,
+    'player_losses', m.player_losses,
+    'player_deck', m.internal_match -> 'playerDeck',
+    'action_log', m.internal_match -> 'actionLog',
+    'opp_deck_colors', m.opp_deck_colors,
+    'opp_name', m.internal_match -> 'opponent' ->> 'name',
+    'player_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'player' ->> 'rank',
+      'tier', m.internal_match -> 'player' -> 'tier',
+      'step', m.internal_match -> 'player' -> 'step',
+      'percentile', m.internal_match -> 'player' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'player' -> 'leaderboardPlace'
+    ),
+    'opp_rank', jsonb_build_object(
+      'rank', m.internal_match -> 'opponent' ->> 'rank',
+      'tier', m.internal_match -> 'opponent' -> 'tier',
+      'step', m.internal_match -> 'opponent' -> 'step',
+      'percentile', m.internal_match -> 'opponent' -> 'percentile',
+      'leaderboardPlace', m.internal_match -> 'opponent' -> 'leaderboardPlace'
+    )
+  )
+  from matches m
+  join visible v on m.user_id = v.user_id and m.arena_id = v.arena_id
+  join target t on true
+  left join profiles p on p.id = t.user_id
+  where m.match_id = p_match_id
+    and not exists (
+      select 1 from deleted_matches dm
+      where dm.user_id = m.user_id and dm.match_id = m.match_id
+    )
+    and coalesce(p.is_private, false) = false;
+$$;


### PR DESCRIPTION
## What this adds

**Player profiles.** Clicking a player on the Home top-ranked feed opens `/profile/<name>` (username in the URL, arena id as fallback): banner with avatar, supporter badge, member-since and last-seen, format chips (Timeless 98% · Brawl…), and both ranks with their **match record over the last 30 days** (season totals reset mid-story). The match list uses the History tab's row layout — deck tile art (with the mythic/rare fallback for draft decks), colors, opponent name and rank, result.

**Public match pages.** Each row opens `/profile/<id>/match/<matchId>`: the played deck beside the full action log, result/event/duration, opponent rank and colors, Export to Arena.

**Patron perks (Standard tier and up, enforced server-side via `entitlements`).** Everyone sees the last 5 matches; entitled callers page through the full history. The **Decks** section shows the player's top 5 decks — versions unified by Arena deck id, records aggregated across them, ranked by the same Wilson lower bound the Home tab uses — each opening the deck's record and its match list. Non-patrons get the redesigned Patreon popup instead (floating marks, tier-coloured perk bullets, and a Become a Patron button that actually renders now — its class name never matched the stylesheet).

**Privacy.**
- `is_private` resolves every lookup to nothing — indistinguishable from "does not exist".
- Profiles expose **one** Arena account (most recently played, or the one pinned in the new Settings selector via `profiles.visible_arena_id`); arena ids are accepted as input but never returned or displayed.
- When an arena id is claimed by several logins it resolves to the most recent claimant; if that person is private the lookup returns nothing rather than falling through.
- Empty deck records from early v7 builds are filtered out of the deck list.

**Pretty usernames.** Signup kept "Manwë" in auth metadata but the profiles trigger only copied the folded login id ("manwe"), so every public surface showed the wrong casing. New `profiles.display_name` column, trigger updated, 211 existing profiles backfilled, and all public reads (including `get_latest_ranks`, so the website leaderboard too) prefer it.

## Database

Five migrations, all already applied to production via MCP (files match the remote history versions): `get_player_profile`, `get_player_matches` (paged, patron-gated, per-deck filter), `get_public_match`, `get_player_decks`, plus `profiles.visible_arena_id` and `profiles.display_name`.

## Test plan

- Verified live against production data in the web build: feed click → profile → match page → back; `/profile/<username>` and `/profile/<arenaId>` both resolve.
- Privacy: flipped a profile private in a self-reverting SQL script — both lookup paths hidden, feed excludes it, restored after.
- Patron gating: anonymous caller asking for 50 matches gets 5; a simulated entitled JWT gets 50 with working offsets; decks list empty + `full_access=false` for non-patrons.
- `tsc`, eslint and the jest suite (84/84) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public player profiles with ranks, format statistics, recent records, match history, and deck summaries.
  * Added detailed public match and deck views, including Arena deck export.
  * Added clickable player names in rankings and shared decks for quick profile access.
  * Added selectable Arena account visibility in account settings.
  * Added supporter-gated profile history and deck browsing.
  * Added signed-out profile access with login return navigation.
  * Refreshed Patreon information with tier perks and updated visuals.

* **Style**
  * Added responsive profile-page styling and updated supporter badge presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->