### PR TITLE
Cache the web card database in IndexedDB, gated on latest.json

### DIFF
--- a/src/utils/cardsDb/__tests__/fetchDatabaseWeb.spec.ts
+++ b/src/utils/cardsDb/__tests__/fetchDatabaseWeb.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * The web database cache: the ~5MB payload must only move when latest.json
+ * names a version newer than the IndexedDB copy. These tests cover the
+ * decision paths that need no gunzip (jsdom has no DecompressionStream): a
+ * fresh cache skips the download entirely, an unreachable latest.json falls
+ * back to the cache, and a missing cache with no network yields null.
+ */
+import { fetchDatabaseWeb } from "../fetchCardsDb";
+
+jest.mock("../../../data/localKV", () => ({
+  kvGet: jest.fn(),
+  kvPut: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { kvGet, kvPut } = require("../../../data/localKV");
+
+/** A buffer starting with the SQLite magic header. */
+function sqliteBytes(): ArrayBuffer {
+  const header = "SQLite format 3";
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < header.length; i += 1) bytes[i] = header.charCodeAt(i);
+  return bytes.buffer;
+}
+
+const realFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(
+  handler: (url: string) => Partial<Response> | null
+): jest.Mock {
+  const mock = jest.fn(async (url: string) => {
+    const res = handler(url);
+    if (!res) throw new Error(`network unavailable for ${url}`);
+    return res as Response;
+  });
+  global.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+describe("fetchDatabaseWeb caching", () => {
+  it("serves the cached copy without downloading when up to date", async () => {
+    kvGet.mockResolvedValue({ version: 231, bytes: sqliteBytes() });
+    const fetchMock = mockFetch((url) =>
+      url.endsWith("latest.json")
+        ? ({
+            ok: true,
+            json: async () => ({
+              latest: 231,
+              updated: 0,
+              formats: ["sqlite"],
+            }),
+          } as Partial<Response>)
+        : null
+    );
+
+    const db = await fetchDatabaseWeb("en");
+
+    expect(db?.source).toBe("cache:v231");
+    // Only the tiny latest.json moved; the payload was never requested.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("latest.json");
+    expect(kvPut).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the cached copy when latest.json is unreachable", async () => {
+    kvGet.mockResolvedValue({ version: 230, bytes: sqliteBytes() });
+    const fetchMock = mockFetch(() => null);
+
+    const db = await fetchDatabaseWeb("en");
+
+    expect(db?.source).toBe("cache:v230");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null with no cache and no network", async () => {
+    kvGet.mockResolvedValue(null);
+    mockFetch(() => null);
+
+    expect(await fetchDatabaseWeb("en")).toBeNull();
+  });
+
+  it("ignores a cached entry that is not a SQLite file", async () => {
+    // A corrupt cache must read as "no cache", not get served.
+    kvGet.mockResolvedValue({ version: 231, bytes: new ArrayBuffer(32) });
+    mockFetch(() => null);
+
+    expect(await fetchDatabaseWeb("en")).toBeNull();
+  });
+});

--- a/src/utils/cardsDb/fetchCardsDb.ts
+++ b/src/utils/cardsDb/fetchCardsDb.ts
@@ -11,6 +11,8 @@
  * sidecar to keep in sync and no need to open the database to find out.
  */
 
+import { kvGet, kvPut } from "../../data/localKV";
+
 // `releases/latest/download/…` always resolves to the newest published release.
 const RELEASE_BASE =
   "https://github.com/mtgatool/mtgatool-metadata/releases/latest/download";
@@ -235,40 +237,115 @@ function gunzipToArrayBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer> {
   return new Response(stream).arrayBuffer();
 }
 
+/** What the web keeps in IndexedDB: the inflated database, named by version. */
+interface CachedWebDb {
+  version: number;
+  bytes: ArrayBuffer;
+}
+
+const webCacheKey = (lang: string): string => `cardsDb:${lang}`;
+
+/** Best-effort reads/writes: a broken IndexedDB must never block the cards. */
+async function readWebCache(lang: string): Promise<CachedWebDb | null> {
+  try {
+    const cached = await kvGet<CachedWebDb>(webCacheKey(lang));
+    if (cached && isSqliteBytes(cached.bytes)) return cached;
+  } catch (e) {
+    /* fall through to the network */
+  }
+  return null;
+}
+
+async function writeWebCache(lang: string, entry: CachedWebDb): Promise<void> {
+  try {
+    await kvPut(webCacheKey(lang), entry);
+  } catch (e) {
+    console.log("[cards-db] could not cache the database locally", e);
+  }
+}
+
+export interface WebDatabase {
+  bytes: ArrayBuffer;
+  /** Where the bytes came from, for the log/source label. */
+  source: string;
+}
+
 /**
- * The web build reads the gzipped mirror — ~17MB becomes ~5MB on the wire, and
- * unlike the GitHub assets it is CORS-readable.
+ * The web counterpart of `ensureDatabaseFile`: the ~5MB payload only moves
+ * when `latest.json` names a version newer than the copy cached in IndexedDB —
+ * the same tiny-check-first flow the desktop uses against its disk cache.
+ * Unlike the browser's HTTP cache (the mirror answers Cache-Control:
+ * no-cache), the IndexedDB copy needs no revalidation round-trip.
+ *
+ * The mirror is read gzipped — ~17MB becomes ~5MB on the wire, and unlike the
+ * GitHub assets it is CORS-readable. The cache keeps the inflated bytes.
  */
 export async function fetchDatabaseWeb(
   lang: string
-): Promise<ArrayBuffer | null> {
+): Promise<WebDatabase | null> {
+  const cached = await readWebCache(lang);
+
+  let latest: LatestInfo | null = null;
   try {
     const latestRes = await fetch(`${SUPABASE_METADATA_BASE}/latest.json`);
-    if (latestRes.ok) {
-      const latest = (await latestRes.json()) as LatestInfo;
-      if (!releaseHasSqlite(latest)) {
-        console.log(
-          `[cards-db] release v${latest.latest} publishes no SQLite database.`
-        );
-        return null;
-      }
-    }
+    if (latestRes.ok) latest = (await latestRes.json()) as LatestInfo;
+  } catch (e) {
+    /* handled below: unreadable latest.json is not fatal */
+  }
 
+  if (latest) {
+    if (!releaseHasSqlite(latest)) {
+      console.log(
+        `[cards-db] release v${latest.latest} publishes no SQLite database.`
+      );
+      return cached
+        ? { bytes: cached.bytes, source: `cache:v${cached.version}` }
+        : null;
+    }
+    if (cached && cached.version >= latest.latest) {
+      console.log(
+        `[cards-db] database up to date (v${cached.version}), using cached copy`
+      );
+      return { bytes: cached.bytes, source: `cache:v${cached.version}` };
+    }
+  } else if (cached) {
+    // Being a version behind is far better than having no cards — and if
+    // latest.json is unreachable, the payload on the same host likely is too.
+    console.log("[cards-db] could not read latest.json, using cached copy");
+    return { bytes: cached.bytes, source: `cache:v${cached.version}` };
+  }
+
+  try {
+    console.log(
+      `[cards-db] downloading ${
+        latest ? `v${latest.latest} ` : ""
+      }${lang} database …`
+    );
     const res = await fetch(
       `${SUPABASE_METADATA_BASE}/${lang}-database.sqlite.gz`
     );
     if (!res.ok) {
       console.log(`[cards-db] mirror returned HTTP ${res.status}`);
-      return null;
+      return cached
+        ? { bytes: cached.bytes, source: `cache:v${cached.version}` }
+        : null;
     }
     const bytes = await gunzipToArrayBuffer(await res.arrayBuffer());
     if (!isSqliteBytes(bytes)) {
       console.log("[cards-db] mirror did not return a SQLite database");
-      return null;
+      return cached
+        ? { bytes: cached.bytes, source: `cache:v${cached.version}` }
+        : null;
     }
-    return bytes;
+    // Version 0 when latest.json was unreadable: never mistaken for newest,
+    // so the next run with a readable latest.json re-checks properly.
+    const version = latest ? latest.latest : 0;
+    await writeWebCache(lang, { version, bytes });
+    return { bytes, source: `mirror:v${version || "?"}` };
   } catch (e) {
     console.log("[cards-db] web database fetch failed", e);
-    return null;
+    return cached
+      ? { bytes: cached.bytes, source: `cache:v${cached.version}` }
+      : null;
   }
 }

--- a/src/utils/cardsDb/loadCardsDbBytes.ts
+++ b/src/utils/cardsDb/loadCardsDbBytes.ts
@@ -145,10 +145,14 @@ async function loadWeb(lang: string): Promise<CardsDbBytes | null> {
       );
     }
 
-    const dbBytes = await fetchDatabaseWeb(lang);
-    if (!dbBytes) return null;
+    const db = await fetchDatabaseWeb(lang);
+    if (!db) return null;
 
-    return { wasmBinary, dbBytes, source: `mirror:${lang}-database.sqlite.gz` };
+    return {
+      wasmBinary,
+      dbBytes: db.bytes,
+      source: `${db.source}:${lang}-database.sqlite`,
+    };
   } catch (e) {
     console.log("[cards-db] web assets failed to load", e);
     return null;


### PR DESCRIPTION
## What

The web build downloads the ~5MB `en-database.sqlite.gz` from the Supabase mirror on **every page load**. `latest.json` is fetched, but only to check that the release publishes SQLite — it is never compared against anything, there is no local cache, and the mirror answers `Cache-Control: no-cache` so the browser's HTTP cache revalidates as well. The Electron build has always had the version-gated disk cache; the web path lost that behavior in the SQLite migration.

This gives the web the same flow against IndexedDB:

- The inflated database is stored in the existing `mtgatool-local` KV store under `cardsDb:{lang}` together with the version it holds.
- Each boot fetches only the tiny `latest.json`; the payload moves solely when the published version is newer than the cached one.
- Unreachable `latest.json` or a failed download serves the cached copy (a version behind beats no cards); a corrupt cache entry is ignored via the SQLite-header check; a broken IndexedDB falls through to the network, never blocking the cards.
- The worker source label distinguishes `cache:vN` from `mirror:vN`.

## Verified

- Live against `npm run start:web`: after the first (seeding) load, a reload's only request to the Supabase bucket is `latest.json` — no `.gz` — and the worker boots from the cached bytes.
- New spec `fetchDatabaseWeb.spec.ts` covers the decision paths: up-to-date cache skips the payload entirely, offline falls back to the cache, no-cache-no-network yields null, corrupt cache is ignored.
- The transfer of `dbBytes` to the worker is safe with the cache: the structured clone into IndexedDB happens at `kvPut` before the buffer is transferred/detached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable web caching for card databases, reducing unnecessary downloads.
  * Uses cached data when release metadata, downloads, decompression, or validation are unavailable.
  * Records the database source and language-specific file details.

* **Bug Fixes**
  * Rejects invalid cached database files.
  * Gracefully returns no database when neither cached nor network data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->