### PR TITLE
Capture specific log entries, on request from admin

### DIFF
--- a/src/background/arena-log-decoder/arena-log-decoder.ts
+++ b/src/background/arena-log-decoder/arena-log-decoder.ts
@@ -124,6 +124,12 @@ function parseLogEntry(
         type: "label_arrow_json",
         ..._.mapValues(rematches.groups, unleakString),
         hash: sha1(jsonString + absPosition),
+        // The raw text, as the label_json branch below also keeps. Without it
+        // an arrow entry carries no record of what was actually written —
+        // `json` has already been unwrapped by tryDecodeJson — so a captured
+        // one arrives with nothing to read. These are the small API payloads;
+        // the large GRE messages match the other branch.
+        text: jsonString,
         json: tryDecodeJson(jsonString),
       },
     ];

--- a/src/background/logEntrySwitch.ts
+++ b/src/background/logEntrySwitch.ts
@@ -1,5 +1,5 @@
 import postChannelMessage from "../broadcastChannel/postChannelMessage";
-import { claimCapturesFor, isLabelWanted } from "../data/logCapture";
+import { claimCapturesFor, isEntryWanted } from "../data/logCapture";
 import LogEntry from "../types/logDecoder";
 import * as Labels from "./onLabel";
 
@@ -21,8 +21,8 @@ export default function logEntrySwitch(entry: LogEntry): void {
   // data/logCapture). Handed to the main window, which owns the cloud writes;
   // the set is empty unless a capture is running, so this is a Set miss on the
   // hot path and nothing more.
-  if (isLabelWanted(entry.label)) {
-    const captureIds = claimCapturesFor(entry.label);
+  if (isEntryWanted(entry.label, entry.arrow)) {
+    const captureIds = claimCapturesFor(entry.label, entry.arrow);
     postChannelMessage({
       type: "LOG_CAPTURE",
       value: {

--- a/src/background/logEntrySwitch.ts
+++ b/src/background/logEntrySwitch.ts
@@ -1,4 +1,5 @@
 import postChannelMessage from "../broadcastChannel/postChannelMessage";
+import { claimCapturesFor, isLabelWanted } from "../data/logCapture";
 import LogEntry from "../types/logDecoder";
 import * as Labels from "./onLabel";
 
@@ -14,6 +15,30 @@ export default function logEntrySwitch(entry: LogEntry): void {
       console.log("Log entry json parse error: ", entry.json);
       console.warn(e);
     }
+  }
+
+  // An admin-configured capture may be asking for this label (see
+  // data/logCapture). Handed to the main window, which owns the cloud writes;
+  // the set is empty unless a capture is running, so this is a Set miss on the
+  // hot path and nothing more.
+  if (isLabelWanted(entry.label)) {
+    const captureIds = claimCapturesFor(entry.label);
+    postChannelMessage({
+      type: "LOG_CAPTURE",
+      value: {
+        captureIds,
+        label: entry.label,
+        hash: entry.hash,
+        timestamp: entry.timestamp,
+        arrow: entry.arrow,
+        type: entry.type,
+        // The raw text, not the parsed object: a fixture wants what Arena
+        // actually wrote, and `entry.json` may have been replaced above.
+        jsonString: entry.jsonString,
+        size: entry.size,
+        position: entry.position,
+      },
+    });
   }
 
   switch (entry.label) {

--- a/src/background/logEntrySwitch.ts
+++ b/src/background/logEntrySwitch.ts
@@ -34,7 +34,9 @@ export default function logEntrySwitch(entry: LogEntry): void {
         type: entry.type,
         // The raw text, not the parsed object: a fixture wants what Arena
         // actually wrote, and `entry.json` may have been replaced above.
-        jsonString: entry.jsonString,
+        // `text` is the field the decoder sets — `jsonString` is declared but
+        // never populated, so capturing it would have stored nothing at all.
+        jsonString: entry.text ?? entry.jsonString,
         size: entry.size,
         position: entry.position,
       },

--- a/src/broadcastChannel/backgroundChannelListeners.ts
+++ b/src/broadcastChannel/backgroundChannelListeners.ts
@@ -1,5 +1,6 @@
 import globalStore from "../background/store";
 import start from "../background/worker";
+import { setActiveCaptures } from "../data/logCapture";
 import bcConnect from "../utils/bcConnect";
 import defaultLogUri from "../utils/defaultLogUri";
 import electron from "../utils/electron/electronWrapper";
@@ -15,6 +16,10 @@ export default function backgroundChannelListeners() {
   let stopFn: undefined | (() => void);
 
   channel.onmessage = (msg: MessageEvent<ChannelMessage>) => {
+    if (msg.data.type == "LOG_CAPTURE_CONFIG") {
+      setActiveCaptures(msg.data.value);
+    }
+
     if (msg.data.type == "START_LOG_READING" && stopFn === undefined) {
       console.log("START LOG READING");
       stopFn = start();

--- a/src/broadcastChannel/channelMessages.ts
+++ b/src/broadcastChannel/channelMessages.ts
@@ -32,6 +32,8 @@ export type MessageType =
   | "OVERLAY_UPDATE_BOUNDS"
   | "OVERLAY_SETTINGS"
   | "GAME_STATS"
+  | "LOG_CAPTURE"
+  | "LOG_CAPTURE_CONFIG"
   | "GAME_START"
   | "SET_SCENE"
   | "UPSERT_DB_CARDS"
@@ -154,6 +156,33 @@ export interface GameStartMessage extends ChannelMessageBase {
 export interface GameStatsMessage extends ChannelMessageBase {
   type: "GAME_STATS";
   value: InternalMatch;
+}
+
+/**
+ * One log entry an active capture asked for (see data/logCapture). The parser
+ * runs in the background window and the cloud writes happen in the main one,
+ * which is why this crosses the channel rather than being uploaded in place.
+ */
+/** The active captures, handed to the parser window at login. */
+export interface LogCaptureConfigMessage extends ChannelMessageBase {
+  type: "LOG_CAPTURE_CONFIG";
+  value: { id: string; labels: string[] }[];
+}
+
+export interface LogCaptureMessage extends ChannelMessageBase {
+  type: "LOG_CAPTURE";
+  value: {
+    /** Captures this entry was claimed by; the parser drops them as it sends. */
+    captureIds: string[];
+    label: string;
+    hash?: string;
+    timestamp?: string;
+    arrow?: string;
+    type?: string;
+    jsonString?: string;
+    size?: number;
+    position?: number;
+  };
 }
 
 export interface SetSceneMessage extends ChannelMessageBase {
@@ -330,6 +359,8 @@ export type ChannelMessage =
   | OverlaySetSettingsMessage
   | OverlayUpdateBoundsMessage
   | GameStatsMessage
+  | LogCaptureMessage
+  | LogCaptureConfigMessage
   | GameStartMessage
   | SetSceneMessage
   | UpsertDbCardsMessage

--- a/src/broadcastChannel/channelMessages.ts
+++ b/src/broadcastChannel/channelMessages.ts
@@ -166,7 +166,12 @@ export interface GameStatsMessage extends ChannelMessageBase {
 /** The active captures, handed to the parser window at login. */
 export interface LogCaptureConfigMessage extends ChannelMessageBase {
   type: "LOG_CAPTURE_CONFIG";
-  value: { id: string; labels: string[] }[];
+  value: {
+    id: string;
+    labels: string[];
+    /** `==>`, `<==`, or absent for either — see data/logCapture. */
+    arrows?: string[] | null;
+  }[];
 }
 
 export interface LogCaptureMessage extends ChannelMessageBase {

--- a/src/broadcastChannel/mainChannelListeners.ts
+++ b/src/broadcastChannel/mainChannelListeners.ts
@@ -4,7 +4,7 @@ import { overlayTitleToId } from "../common/maps";
 import { LOGIN_OK } from "../constants";
 import { pushDraft, pushFormatsSnapshot } from "../data/cloudSync";
 import { isDraftDeleted } from "../data/deletedDrafts";
-import { submitLogCapture } from "../data/logCapture";
+import { submitLogCapture } from "../data/logCaptureSync";
 import setDbMatch from "../data/setDbMatch";
 import { getUserNamespacedKey, putData } from "../data/store";
 import syncDrafts from "../data/syncDrafts";

--- a/src/broadcastChannel/mainChannelListeners.ts
+++ b/src/broadcastChannel/mainChannelListeners.ts
@@ -4,6 +4,7 @@ import { overlayTitleToId } from "../common/maps";
 import { LOGIN_OK } from "../constants";
 import { pushDraft, pushFormatsSnapshot } from "../data/cloudSync";
 import { isDraftDeleted } from "../data/deletedDrafts";
+import { submitLogCapture } from "../data/logCapture";
 import setDbMatch from "../data/setDbMatch";
 import { getUserNamespacedKey, putData } from "../data/store";
 import syncDrafts from "../data/syncDrafts";
@@ -155,6 +156,10 @@ export default function mainChannelListeners() {
           globalData.readerReads.length - READER_READS_KEPT
         );
       }
+    }
+
+    if (msg.data.type === "LOG_CAPTURE") {
+      submitLogCapture(msg.data.value);
     }
 
     if (msg.data.type === "GAME_START") {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,7 +14,7 @@ import { getCloudSession } from "../data/cloudAuth";
 import { getActiveUserId } from "../data/cloudSync";
 import hydrateFromCloud from "../data/hydrateFromCloud";
 import localLogin from "../data/localLogin";
-import { loadLogCaptures } from "../data/logCapture";
+import { loadLogCaptures } from "../data/logCaptureSync";
 import syncMatches from "../data/syncMatches";
 import { useCardArtCrop } from "../hooks/useCardImage";
 import info from "../info.json";

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,6 +14,7 @@ import { getCloudSession } from "../data/cloudAuth";
 import { getActiveUserId } from "../data/cloudSync";
 import hydrateFromCloud from "../data/hydrateFromCloud";
 import localLogin from "../data/localLogin";
+import { loadLogCaptures } from "../data/logCapture";
 import syncMatches from "../data/syncMatches";
 import { useCardArtCrop } from "../hooks/useCardImage";
 import info from "../info.json";
@@ -173,6 +174,11 @@ function App(props: AppProps) {
 
               // Reconcile local match history with the cloud (no-op offline).
               syncMatches().catch(() => undefined);
+
+              // Ask whether admin wants any log labels captured this session.
+              // Read once, here, so a capture created today reaches people as
+              // they sign in over the next day rather than mid-session.
+              loadLogCaptures().catch(() => undefined);
 
               if (
                 history.location.pathname === "" ||

--- a/src/data/__tests__/logCapture.spec.ts
+++ b/src/data/__tests__/logCapture.spec.ts
@@ -4,18 +4,15 @@
  * The server enforces the real limits, but a client that kept matching a label
  * would keep sending for the whole session and rely on the server to say no
  * every time. These are the rules that make it quiet instead.
+ *
+ * No mocks: this half imports nothing, which is the point of it being separate
+ * from logCaptureSync.
  */
 import {
   claimCapturesFor,
   isLabelWanted,
   setActiveCaptures,
 } from "../logCapture";
-
-jest.mock("../supabase", () => ({ __esModule: true, default: {} }));
-jest.mock("../../broadcastChannel/postChannelMessage", () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
 
 afterEach(() => setActiveCaptures([]));
 

--- a/src/data/__tests__/logCapture.spec.ts
+++ b/src/data/__tests__/logCapture.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * The parser-side rules of log capture.
+ *
+ * The server enforces the real limits, but a client that kept matching a label
+ * would keep sending for the whole session and rely on the server to say no
+ * every time. These are the rules that make it quiet instead.
+ */
+import {
+  claimCapturesFor,
+  isLabelWanted,
+  setActiveCaptures,
+} from "../logCapture";
+
+jest.mock("../supabase", () => ({ __esModule: true, default: {} }));
+jest.mock("../../broadcastChannel/postChannelMessage", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+afterEach(() => setActiveCaptures([]));
+
+describe("log capture matching", () => {
+  it("wants nothing until a capture says so", () => {
+    expect(isLabelWanted("GreToClientEvent")).toBe(false);
+  });
+
+  it("matches only the labels a capture asked for", () => {
+    setActiveCaptures([{ id: "c1", labels: ["Event_Join"] }]);
+    expect(isLabelWanted("Event_Join")).toBe(true);
+    expect(isLabelWanted("GreToClientEvent")).toBe(false);
+  });
+
+  it("claims a capture once and then goes quiet", () => {
+    setActiveCaptures([{ id: "c1", labels: ["Event_Join"] }]);
+
+    expect(claimCapturesFor("Event_Join")).toEqual(["c1"]);
+    // Second sighting of the same label sends nothing: one entry per capture
+    // per session, decided here rather than by asking the server again.
+    expect(claimCapturesFor("Event_Join")).toEqual([]);
+    expect(isLabelWanted("Event_Join")).toBe(false);
+  });
+
+  it("claims every capture watching a label at once", () => {
+    setActiveCaptures([
+      { id: "c1", labels: ["Event_Join"] },
+      { id: "c2", labels: ["Event_Join", "Event_DeckSubmit"] },
+    ]);
+
+    expect(claimCapturesFor("Event_Join").sort()).toEqual(["c1", "c2"]);
+    // c2 wanted two labels but has had its one entry, so the other stops too.
+    expect(isLabelWanted("Event_DeckSubmit")).toBe(false);
+  });
+
+  it("leaves other captures alone", () => {
+    setActiveCaptures([
+      { id: "c1", labels: ["Event_Join"] },
+      { id: "c2", labels: ["Event_DeckSubmit"] },
+    ]);
+
+    claimCapturesFor("Event_Join");
+
+    expect(isLabelWanted("Event_DeckSubmit")).toBe(true);
+    expect(claimCapturesFor("Event_DeckSubmit")).toEqual(["c2"]);
+  });
+
+  it("ignores a capture with no labels", () => {
+    setActiveCaptures([{ id: "c1", labels: [] }]);
+    expect(isLabelWanted("Event_Join")).toBe(false);
+  });
+});

--- a/src/data/__tests__/logCapture.spec.ts
+++ b/src/data/__tests__/logCapture.spec.ts
@@ -10,6 +10,7 @@
  */
 import {
   claimCapturesFor,
+  isEntryWanted,
   isLabelWanted,
   setActiveCaptures,
 } from "../logCapture";
@@ -58,6 +59,33 @@ describe("log capture matching", () => {
 
     expect(isLabelWanted("Event_DeckSubmit")).toBe(true);
     expect(claimCapturesFor("Event_DeckSubmit")).toEqual(["c2"]);
+  });
+
+  it("takes the direction the capture asked for", () => {
+    // The outbound request always precedes the response, so without this a
+    // request/response label can only ever capture the empty envelope: the
+    // real EventGetCoursesV2 capture came back as `{"request":"{}"}`.
+    setActiveCaptures([
+      { id: "c1", labels: ["EventGetCoursesV2"], arrows: ["<=="] },
+    ]);
+
+    expect(isEntryWanted("EventGetCoursesV2", "==>")).toBe(false);
+    expect(claimCapturesFor("EventGetCoursesV2", "==>")).toEqual([]);
+
+    expect(isEntryWanted("EventGetCoursesV2", "<==")).toBe(true);
+    expect(claimCapturesFor("EventGetCoursesV2", "<==")).toEqual(["c1"]);
+  });
+
+  it("takes either direction when none was asked for", () => {
+    setActiveCaptures([{ id: "c1", labels: ["Event_Join"] }]);
+    expect(isEntryWanted("Event_Join", "==>")).toBe(true);
+    // Entries from the other decoder branch carry no arrow at all.
+    expect(isEntryWanted("Event_Join", undefined)).toBe(true);
+  });
+
+  it("does not match an arrowless entry when a direction was asked for", () => {
+    setActiveCaptures([{ id: "c1", labels: ["Event_Join"], arrows: ["<=="] }]);
+    expect(isEntryWanted("Event_Join", undefined)).toBe(false);
   });
 
   it("ignores a capture with no labels", () => {

--- a/src/data/logCapture.ts
+++ b/src/data/logCapture.ts
@@ -21,16 +21,17 @@
  * the main window, which owns the Supabase session; matching happens in the
  * background window, where the log is parsed. They meet over the broadcast
  * channel, which is why the config is handed across rather than read twice.
+ *
+ * THIS module is the parser half, and it deliberately imports nothing — no
+ * Supabase client, no channel. Importing the client here would construct a
+ * second auth client in the background window against the same stored
+ * session, which is a token-refresh race nobody asked for, on the window that
+ * must never stall. The uploading half lives in `logCaptureSync`.
  */
-import postChannelMessage from "../broadcastChannel/postChannelMessage";
-import supabase from "./supabase";
-
 export interface LogCapture {
   id: string;
   labels: string[];
 }
-
-/* ------------------------------------------------ background (parser) side */
 
 /** Captures still worth watching in this window, for this session. */
 let active: LogCapture[] = [];
@@ -77,64 +78,4 @@ export function claimCapturesFor(label: string): string[] {
     reindex();
   }
   return ids;
-}
-
-/* ------------------------------------------------------- main window side */
-
-/**
- * Fetch the active captures and hand them to the parser.
- *
- * Best-effort in every direction: a failure means capture nothing, which is
- * also the default. Called once per login.
- */
-export async function loadLogCaptures(): Promise<void> {
-  try {
-    const { data, error } = await (supabase as any)
-      .from("log_captures")
-      .select("id, labels")
-      .eq("active", true);
-
-    if (error || !data?.length) return;
-
-    postChannelMessage({
-      type: "LOG_CAPTURE_CONFIG",
-      value: data as LogCapture[],
-    });
-  } catch (e) {
-    // Nothing to do: no config means no capture.
-  }
-}
-
-/** Upload one captured entry to each capture that claimed it. */
-export async function submitLogCapture(value: {
-  captureIds: string[];
-  label: string;
-  hash?: string;
-  timestamp?: string;
-  arrow?: string;
-  type?: string;
-  jsonString?: string;
-  size?: number;
-  position?: number;
-}): Promise<void> {
-  await Promise.all(
-    (value.captureIds || []).map(async (captureId) => {
-      try {
-        const { error } = await (supabase as any).rpc("submit_log_capture", {
-          p_capture_id: captureId,
-          p_label: value.label,
-          p_hash: value.hash ?? null,
-          p_timestamp: value.timestamp ?? null,
-          p_arrow: value.arrow ?? null,
-          p_type: value.type ?? null,
-          p_json_string: value.jsonString ?? null,
-          p_size: value.size ?? null,
-          p_position: value.position ?? null,
-        });
-        if (!error) console.log(`[log-capture] sent ${value.label}`);
-      } catch (e) {
-        // Opportunistic debugging data is never worth a retry loop.
-      }
-    })
-  );
 }

--- a/src/data/logCapture.ts
+++ b/src/data/logCapture.ts
@@ -50,11 +50,7 @@ function reindex(): void {
 }
 
 /** Whether a capture wants this entry, label and direction both. */
-function matches(
-  capture: LogCapture,
-  label: string,
-  arrow?: string
-): boolean {
+function matches(capture: LogCapture, label: string, arrow?: string): boolean {
   if (!capture.labels.includes(label)) return false;
   // No direction asked for: either will do, including entries that have none.
   if (!capture.arrows?.length) return true;

--- a/src/data/logCapture.ts
+++ b/src/data/logCapture.ts
@@ -1,0 +1,140 @@
+/* eslint-disable no-console */
+/**
+ * Targeted log capture, configured from the admin panel.
+ *
+ * Some parsing bugs only occur in situations we cannot reproduce locally — a
+ * direct challenge you did not start, an event that ran for two days. When one
+ * turns up, admin names the log label it needs and a handful of clients send
+ * that entry the next time they see it.
+ *
+ * The rules that keep this small, and honest:
+ *
+ * - Only labels admin explicitly asked for. Never "everything".
+ * - The list is fetched **at login**, so a capture added today reaches people
+ *   as they sign in over the following day rather than mid-session.
+ * - A client sends **one entry per capture, once**, then forgets that capture
+ *   for the rest of the session.
+ * - The server enforces the real limits (one row per user, and a cap across
+ *   the whole system), so a client cannot overshoot by racing.
+ *
+ * The two halves run in different windows. Fetching and uploading happen in
+ * the main window, which owns the Supabase session; matching happens in the
+ * background window, where the log is parsed. They meet over the broadcast
+ * channel, which is why the config is handed across rather than read twice.
+ */
+import postChannelMessage from "../broadcastChannel/postChannelMessage";
+import supabase from "./supabase";
+
+export interface LogCapture {
+  id: string;
+  labels: string[];
+}
+
+/* ------------------------------------------------ background (parser) side */
+
+/** Captures still worth watching in this window, for this session. */
+let active: LogCapture[] = [];
+let wanted = new Set<string>();
+
+function reindex(): void {
+  wanted = new Set(active.flatMap((capture) => capture.labels));
+}
+
+/** Apply a config handed over from the main window. */
+export function setActiveCaptures(captures: LogCapture[]): void {
+  active = (captures || []).filter((capture) => capture.labels?.length);
+  reindex();
+  if (active.length) {
+    console.log(
+      `[log-capture] watching ${wanted.size} label(s) for ${active.length} capture(s)`
+    );
+  }
+}
+
+/**
+ * Whether any active capture wants this label.
+ *
+ * Called for every log entry, so it stays a Set lookup against a set that is
+ * empty unless a capture is running.
+ */
+export function isLabelWanted(label: string): boolean {
+  return wanted.size > 0 && wanted.has(label);
+}
+
+/**
+ * Claim the captures asking for this label, removing them as it goes.
+ *
+ * Claiming and forgetting in one step is what makes "one entry per capture per
+ * session" true without a round trip: by the time the entry is on its way, no
+ * later entry can match the same capture again.
+ */
+export function claimCapturesFor(label: string): string[] {
+  const ids = active
+    .filter((capture) => capture.labels.includes(label))
+    .map((capture) => capture.id);
+  if (ids.length) {
+    active = active.filter((capture) => !ids.includes(capture.id));
+    reindex();
+  }
+  return ids;
+}
+
+/* ------------------------------------------------------- main window side */
+
+/**
+ * Fetch the active captures and hand them to the parser.
+ *
+ * Best-effort in every direction: a failure means capture nothing, which is
+ * also the default. Called once per login.
+ */
+export async function loadLogCaptures(): Promise<void> {
+  try {
+    const { data, error } = await (supabase as any)
+      .from("log_captures")
+      .select("id, labels")
+      .eq("active", true);
+
+    if (error || !data?.length) return;
+
+    postChannelMessage({
+      type: "LOG_CAPTURE_CONFIG",
+      value: data as LogCapture[],
+    });
+  } catch (e) {
+    // Nothing to do: no config means no capture.
+  }
+}
+
+/** Upload one captured entry to each capture that claimed it. */
+export async function submitLogCapture(value: {
+  captureIds: string[];
+  label: string;
+  hash?: string;
+  timestamp?: string;
+  arrow?: string;
+  type?: string;
+  jsonString?: string;
+  size?: number;
+  position?: number;
+}): Promise<void> {
+  await Promise.all(
+    (value.captureIds || []).map(async (captureId) => {
+      try {
+        const { error } = await (supabase as any).rpc("submit_log_capture", {
+          p_capture_id: captureId,
+          p_label: value.label,
+          p_hash: value.hash ?? null,
+          p_timestamp: value.timestamp ?? null,
+          p_arrow: value.arrow ?? null,
+          p_type: value.type ?? null,
+          p_json_string: value.jsonString ?? null,
+          p_size: value.size ?? null,
+          p_position: value.position ?? null,
+        });
+        if (!error) console.log(`[log-capture] sent ${value.label}`);
+      } catch (e) {
+        // Opportunistic debugging data is never worth a retry loop.
+      }
+    })
+  );
+}

--- a/src/data/logCapture.ts
+++ b/src/data/logCapture.ts
@@ -31,6 +31,14 @@
 export interface LogCapture {
   id: string;
   labels: string[];
+  /**
+   * Which direction of the label to take: `==>`, `<==`, or both when empty.
+   *
+   * Request/response labels appear twice and a capture is claimed by the FIRST
+   * match, which is always the outbound request — usually an empty envelope,
+   * while the response is the thing worth reading.
+   */
+  arrows?: string[] | null;
 }
 
 /** Captures still worth watching in this window, for this session. */
@@ -39,6 +47,18 @@ let wanted = new Set<string>();
 
 function reindex(): void {
   wanted = new Set(active.flatMap((capture) => capture.labels));
+}
+
+/** Whether a capture wants this entry, label and direction both. */
+function matches(
+  capture: LogCapture,
+  label: string,
+  arrow?: string
+): boolean {
+  if (!capture.labels.includes(label)) return false;
+  // No direction asked for: either will do, including entries that have none.
+  if (!capture.arrows?.length) return true;
+  return !!arrow && capture.arrows.includes(arrow);
 }
 
 /** Apply a config handed over from the main window. */
@@ -62,6 +82,12 @@ export function isLabelWanted(label: string): boolean {
   return wanted.size > 0 && wanted.has(label);
 }
 
+/** Whether any capture wants this entry once direction is taken into account. */
+export function isEntryWanted(label: string, arrow?: string): boolean {
+  if (!isLabelWanted(label)) return false;
+  return active.some((capture) => matches(capture, label, arrow));
+}
+
 /**
  * Claim the captures asking for this label, removing them as it goes.
  *
@@ -69,9 +95,9 @@ export function isLabelWanted(label: string): boolean {
  * session" true without a round trip: by the time the entry is on its way, no
  * later entry can match the same capture again.
  */
-export function claimCapturesFor(label: string): string[] {
+export function claimCapturesFor(label: string, arrow?: string): string[] {
   const ids = active
-    .filter((capture) => capture.labels.includes(label))
+    .filter((capture) => matches(capture, label, arrow))
     .map((capture) => capture.id);
   if (ids.length) {
     active = active.filter((capture) => !ids.includes(capture.id));

--- a/src/data/logCaptureSync.ts
+++ b/src/data/logCaptureSync.ts
@@ -21,7 +21,7 @@ export async function loadLogCaptures(): Promise<void> {
   try {
     const { data, error } = await (supabase as any)
       .from("log_captures")
-      .select("id, labels")
+      .select("id, labels, arrows")
       .eq("active", true);
 
     if (error || !data?.length) return;

--- a/src/data/logCaptureSync.ts
+++ b/src/data/logCaptureSync.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+/**
+ * The network half of log capture: reading the active captures at login and
+ * uploading what the parser claimed.
+ *
+ * Separate from `logCapture` on purpose — that module runs in the background
+ * window and must not pull in a Supabase client (see the note there). This one
+ * is only ever imported by the main window.
+ */
+import postChannelMessage from "../broadcastChannel/postChannelMessage";
+import { LogCapture } from "./logCapture";
+import supabase from "./supabase";
+
+/**
+ * Fetch the active captures and hand them to the parser.
+ *
+ * Best-effort in every direction: a failure means capture nothing, which is
+ * also the default. Called once per login.
+ */
+export async function loadLogCaptures(): Promise<void> {
+  try {
+    const { data, error } = await (supabase as any)
+      .from("log_captures")
+      .select("id, labels")
+      .eq("active", true);
+
+    if (error || !data?.length) return;
+
+    postChannelMessage({
+      type: "LOG_CAPTURE_CONFIG",
+      value: data as LogCapture[],
+    });
+  } catch (e) {
+    // Nothing to do: no config means no capture.
+  }
+}
+
+/** Upload one captured entry to each capture that claimed it. */
+export async function submitLogCapture(value: {
+  captureIds: string[];
+  label: string;
+  hash?: string;
+  timestamp?: string;
+  arrow?: string;
+  type?: string;
+  jsonString?: string;
+  size?: number;
+  position?: number;
+}): Promise<void> {
+  await Promise.all(
+    (value.captureIds || []).map(async (captureId) => {
+      try {
+        const { error } = await (supabase as any).rpc("submit_log_capture", {
+          p_capture_id: captureId,
+          p_label: value.label,
+          p_hash: value.hash ?? null,
+          p_timestamp: value.timestamp ?? null,
+          p_arrow: value.arrow ?? null,
+          p_type: value.type ?? null,
+          p_json_string: value.jsonString ?? null,
+          p_size: value.size ?? null,
+          p_position: value.position ?? null,
+        });
+        if (!error) console.log(`[log-capture] sent ${value.label}`);
+      } catch (e) {
+        // Opportunistic debugging data is never worth a retry loop.
+      }
+    })
+  );
+}

--- a/src/types/logDecoder.ts
+++ b/src/types/logDecoder.ts
@@ -4,6 +4,19 @@ export default interface LogEntry {
   timestamp: string;
   arrow: string;
   type: string;
+  /**
+   * The entry's raw JSON text, exactly as it appears in the log.
+   *
+   * This is the field the decoder actually sets (`text: jsonString` in
+   * arena-log-decoder). `jsonString` below is declared but never populated —
+   * see the note there.
+   */
+  text?: string;
+  /**
+   * @deprecated Never set. The decoder emits `text`; anything reading this
+   * gets undefined, which is why the summarised-GRE guard in GreToClient has
+   * been dead for as long as it has existed.
+   */
   jsonString?: string;
   json: any;
   size: number;

--- a/supabase/migrations/20260818112905_log_captures.sql
+++ b/supabase/migrations/20260818112905_log_captures.sql
@@ -130,16 +130,3 @@ $$;
 
 revoke all on function public.submit_log_capture from public;
 grant execute on function public.submit_log_capture to authenticated;
-
--- Which direction of a label to capture.
---
--- Request/response labels are logged twice, `==>` then `<==`, and a client
--- claims a capture on the FIRST match it sees — which is always the outbound
--- request. For EventGetCoursesV2 that is a 60-byte `{"request":"{}"}` and the
--- response carrying every course is never captured at all.
---
--- Null or empty means either direction, which is right for the labels that
--- have no arrow (the GRE messages take the decoder's other branch and carry
--- none).
-alter table public.log_captures
-  add column if not exists arrows text[];

--- a/supabase/migrations/20260818114843_log_captures_arrow_filter.sql
+++ b/supabase/migrations/20260818114843_log_captures_arrow_filter.sql
@@ -1,0 +1,12 @@
+-- Which direction of a label to capture.
+--
+-- Request/response labels are logged twice, `==>` then `<==`, and a client
+-- claims a capture on the FIRST match it sees — which is always the outbound
+-- request. For EventGetCoursesV2 that is a 60-byte `{"request":"{}"}` and the
+-- response carrying every course is never captured at all.
+--
+-- Null or empty means either direction, which is right for the labels that
+-- have no arrow (the GRE messages take the decoder's other branch and carry
+-- none).
+alter table public.log_captures
+  add column if not exists arrows text[];

--- a/supabase/migrations/20260818120000_log_captures.sql
+++ b/supabase/migrations/20260818120000_log_captures.sql
@@ -1,0 +1,132 @@
+-- Targeted log capture.
+--
+-- Some parsing bugs only happen in situations we cannot reproduce: a direct
+-- challenge you did not start, a Midweek Magic event that ran for two days, a
+-- GRE message Arena summarised away. The commander bug fixed in the desktop
+-- was diagnosed from database ratios rather than from a log, because no log of
+-- the failing case existed anywhere we could reach.
+--
+-- This lets us ask, from admin, for a specific log label — and stop asking as
+-- soon as we have enough. It is deliberately small: a handful of events, one
+-- per user, and the client goes quiet for the rest of its session the moment
+-- it has contributed.
+
+create table if not exists public.log_captures (
+  id uuid primary key default gen_random_uuid(),
+  -- What this capture is for, in words, so a stale one is recognisable later.
+  name text not null,
+  -- entry.label values to match, exactly as the log parser sees them.
+  labels text[] not null,
+  -- Across the whole system, not per user. Five is usually plenty: these are
+  -- for reading, not for statistics.
+  max_events integer not null default 5 check (max_events between 1 and 100),
+  active boolean not null default true,
+  notes text,
+  created_at timestamptz not null default now(),
+  created_by uuid references auth.users (id) on delete set null
+);
+
+create table if not exists public.log_capture_events (
+  id uuid primary key default gen_random_uuid(),
+  capture_id uuid not null references public.log_captures (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  -- The log entry, in the shape the parser hands to logEntrySwitch.
+  label text not null,
+  entry_hash text,
+  entry_timestamp text,
+  arrow text,
+  entry_type text,
+  json_string text,
+  size integer,
+  position bigint,
+  created_at timestamptz not null default now(),
+  -- One per user per capture: five events from five people is a far better
+  -- sample than five from whoever happened to play first.
+  unique (capture_id, user_id)
+);
+
+create index if not exists log_capture_events_capture_idx
+  on public.log_capture_events (capture_id, created_at desc);
+
+alter table public.log_captures enable row level security;
+alter table public.log_capture_events enable row level security;
+
+-- Clients read the active captures to know what to watch for. The rows carry
+-- no user data — they are a list of log labels — and every client needs them.
+drop policy if exists "log_captures readable" on public.log_captures;
+create policy "log_captures readable" on public.log_captures
+  for select to authenticated using (true);
+
+-- Nobody writes captured events directly: submission goes through the function
+-- below, which enforces the limit. No select policy at all, so the events are
+-- reachable only with the service role (i.e. the admin panel).
+drop policy if exists "log_capture_events no direct access" on public.log_capture_events;
+
+/**
+ * Submit one captured log entry.
+ *
+ * Returns true when it was stored. False means "we have enough, stop sending"
+ * — the capture filled up, went inactive, or this user already contributed.
+ * The client treats both the same way: drop the capture for the session.
+ *
+ * The row is locked before counting so two clients submitting at the same
+ * moment cannot both see four events and both insert a fifth.
+ */
+create or replace function public.submit_log_capture(
+  p_capture_id uuid,
+  p_label text,
+  p_hash text,
+  p_timestamp text,
+  p_arrow text,
+  p_type text,
+  p_json_string text,
+  p_size integer,
+  p_position bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_max integer;
+  v_count integer;
+begin
+  if auth.uid() is null then
+    return false;
+  end if;
+
+  select max_events into v_max
+    from log_captures
+   where id = p_capture_id and active
+     for update;
+
+  if v_max is null then
+    return false;
+  end if;
+
+  select count(*) into v_count
+    from log_capture_events
+   where capture_id = p_capture_id;
+
+  if v_count >= v_max then
+    return false;
+  end if;
+
+  insert into log_capture_events (
+    capture_id, user_id, label, entry_hash, entry_timestamp,
+    arrow, entry_type, json_string, size, position
+  ) values (
+    p_capture_id, auth.uid(), p_label, p_hash, p_timestamp,
+    p_arrow, p_type, p_json_string, p_size, p_position
+  )
+  on conflict (capture_id, user_id) do nothing;
+
+  -- A conflict means this user already contributed; either way they should
+  -- stop sending, so the answer is the same.
+  return found;
+end;
+$$;
+
+revoke all on function public.submit_log_capture from public;
+grant execute on function public.submit_log_capture to authenticated;

--- a/supabase/migrations/20260818120000_log_captures.sql
+++ b/supabase/migrations/20260818120000_log_captures.sql
@@ -130,3 +130,16 @@ $$;
 
 revoke all on function public.submit_log_capture from public;
 grant execute on function public.submit_log_capture to authenticated;
+
+-- Which direction of a label to capture.
+--
+-- Request/response labels are logged twice, `==>` then `<==`, and a client
+-- claims a capture on the FIRST match it sees — which is always the outbound
+-- request. For EventGetCoursesV2 that is a 60-byte `{"request":"{}"}` and the
+-- response carrying every course is never captured at all.
+--
+-- Null or empty means either direction, which is right for the labels that
+-- have no arrow (the GRE messages take the decoder's other branch and carry
+-- none).
+alter table public.log_captures
+  add column if not exists arrows text[];


### PR DESCRIPTION
Companion PR: **mtgatool-admin** (the panel that configures these captures).

## Why

Some parsing bugs only happen in situations we cannot reproduce locally — a direct challenge you did not start, an event that ran for two days, a GRE message Arena summarised away. The commander bug fixed in `18f5980` was diagnosed from *database ratios* rather than from a log, because no log of the failing case existed anywhere we could reach; its test fixture had to be reasoned about instead of captured.

This lets admin ask for a specific log label and get a handful of real entries back — each one a ready-made test fixture.

## How it works

Admin creates a capture naming one or more `entry.label` values and a cap (5 by default). Clients read the active captures **at login**, so a capture created today reaches people as they sign in over the following day. When the parser sees a matching label it sends that one entry and stops.

Four rules keep it small:

- **Only what was asked for.** No "capture everything" mode; the matching set is empty unless a capture is running, so the cost on the parsing hot path is a miss against an empty `Set`.
- **One entry per capture, per client, per session.** Claiming and forgetting happen in the same step (`claimCapturesFor`), so no later entry can match the same capture again — and it needs no round trip to decide.
- **The server enforces the real limits**: one row per user (unique constraint) and a cap across the whole system, checked inside a locked transaction so two clients cannot both insert the fifth event.
- **Whole entries, not whole logs.** What is stored is the fields the parser already has: label, hash, timestamp, arrow, type, the raw `jsonString`, size and position.

## Where the pieces live

Fetching and uploading run in the **main** window, which owns the Supabase session; matching runs in the **background** window, where the log is parsed. They are separate renderers with separate module state, which is why the config crosses the broadcast channel rather than being read twice.

## Migration

`supabase/migrations/20260818120000_log_captures.sql` is included and **has not been applied**. It adds `log_captures`, `log_capture_events`, and the `submit_log_capture` function. Captured events have no `select` policy at all, so they are reachable only with the service role — i.e. the admin panel.

## Tests

Six tests covering the parser-side rules, including the one that matters most: a label seen twice sends once. Full suite 125 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targeted log capture for matching log entries, with optional direction filtering.
  * Captured entries can be submitted with relevant metadata and raw log content.
  * Capture configurations load automatically after login.
  * Supports one-time capture claims and configurable event limits.
* **Bug Fixes**
  * Prevents unrelated entries and duplicate captures from being submitted.
  * Preserves raw JSON content across supported log formats.
* **Tests**
  * Added coverage for matching, isolation, state resets, and multi-capture scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->