### PR TITLE
Stop live-share from writing while signed out

### DIFF
--- a/src/data/liveShareServer.ts
+++ b/src/data/liveShareServer.ts
@@ -9,6 +9,7 @@
  */
 import { ChannelMessage } from "../broadcastChannel/channelMessages";
 import bcConnect from "../utils/bcConnect";
+import { getActiveUserId } from "./cloudSync";
 import supabase from "./supabase";
 
 // A write in flight per shareId. The overlay re-sends on its throttle/keepalive
@@ -16,41 +17,65 @@ import supabase from "./supabase";
 // beat (~1s) instead of letting writes pile up — matching the old inflight guard.
 const inflight = new Set<string>();
 
+// shareIds we have already reported as unpublishable, so the log carries one
+// line per share rather than one per keepalive beat.
+const warned = new Set<string>();
+
 let serving = false;
 
-function upsert(shareId: string, payload: unknown): void {
+/**
+ * True when there is a session to write with. `live_overlays` rows default
+ * `user_id` to `auth.uid()` and only `authenticated` may write them, so a
+ * request made in local/offline mode goes out as `anon` and Postgres rejects it
+ * (42501, surfaced as HTTP 401). The overlay keeps its keepalive beating for as
+ * long as the window is open, so an ungated write repeats that rejection every
+ * few seconds — drop the message instead.
+ */
+async function canPublish(shareId: string, action: string): Promise<boolean> {
+  if (await getActiveUserId()) {
+    warned.delete(shareId);
+    return true;
+  }
+  if (!warned.has(shareId)) {
+    warned.add(shareId);
+    // eslint-disable-next-line no-console
+    console.warn(`[liveShare] ${action} ${shareId} skipped: not logged in`);
+  }
+  return false;
+}
+
+async function upsert(shareId: string, payload: unknown): Promise<void> {
   if (inflight.has(shareId)) return;
   inflight.add(shareId);
-  supabase
-    .from("live_overlays")
-    .upsert(
+  try {
+    if (!(await canPublish(shareId, "upsert"))) return;
+    const { error } = await supabase.from("live_overlays").upsert(
       {
         share_id: shareId,
         payload: payload as never,
         updated_at: new Date().toISOString(),
       },
       { onConflict: "share_id" }
-    )
-    .then(({ error }) => {
-      inflight.delete(shareId);
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.warn(`[liveShare] upsert ${shareId} failed:`, error.message);
-      }
-    });
+    );
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.warn(`[liveShare] upsert ${shareId} failed:`, error.message);
+    }
+  } finally {
+    inflight.delete(shareId);
+  }
 }
 
-function remove(shareId: string): void {
-  supabase
+async function remove(shareId: string): Promise<void> {
+  if (!(await canPublish(shareId, "delete"))) return;
+  const { error } = await supabase
     .from("live_overlays")
     .delete()
-    .eq("share_id", shareId)
-    .then(({ error }) => {
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.warn(`[liveShare] delete ${shareId} failed:`, error.message);
-      }
-    });
+    .eq("share_id", shareId);
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`[liveShare] delete ${shareId} failed:`, error.message);
+  }
 }
 
 /**

--- a/src/data/liveShareServer.ts
+++ b/src/data/liveShareServer.ts
@@ -12,10 +12,11 @@ import bcConnect from "../utils/bcConnect";
 import { getActiveUserId } from "./cloudSync";
 import supabase from "./supabase";
 
-// A write in flight per shareId. The overlay re-sends on its throttle/keepalive
-// beat, so dropping a message that arrives mid-write just defers it to the next
-// beat (~1s) instead of letting writes pile up — matching the old inflight guard.
-const inflight = new Set<string>();
+// The write in flight per shareId, kept as a promise so a stop can wait for it.
+// The overlay re-sends on its throttle/keepalive beat, so dropping a message
+// that arrives mid-write just defers it to the next beat (~1s) instead of
+// letting writes pile up.
+const inflight = new Map<string, Promise<void>>();
 
 // shareIds we have already reported as unpublishable, so the log carries one
 // line per share rather than one per keepalive beat.
@@ -44,29 +45,37 @@ async function canPublish(shareId: string, action: string): Promise<boolean> {
   return false;
 }
 
-async function upsert(shareId: string, payload: unknown): Promise<void> {
-  if (inflight.has(shareId)) return;
-  inflight.add(shareId);
-  try {
-    if (!(await canPublish(shareId, "upsert"))) return;
-    const { error } = await supabase.from("live_overlays").upsert(
-      {
-        share_id: shareId,
-        payload: payload as never,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "share_id" }
-    );
-    if (error) {
-      // eslint-disable-next-line no-console
-      console.warn(`[liveShare] upsert ${shareId} failed:`, error.message);
-    }
-  } finally {
-    inflight.delete(shareId);
+async function publish(shareId: string, payload: unknown): Promise<void> {
+  if (!(await canPublish(shareId, "upsert"))) return;
+  const { error } = await supabase.from("live_overlays").upsert(
+    {
+      share_id: shareId,
+      payload: payload as never,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "share_id" }
+  );
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`[liveShare] upsert ${shareId} failed:`, error.message);
   }
 }
 
+async function upsert(shareId: string, payload: unknown): Promise<void> {
+  if (inflight.has(shareId)) return;
+  const write = publish(shareId, payload);
+  inflight.set(shareId, write);
+  await write.catch(() => undefined);
+  if (inflight.get(shareId) === write) inflight.delete(shareId);
+}
+
 async function remove(shareId: string): Promise<void> {
+  // Wait out a publish already on the wire. It would otherwise be free to land
+  // after the delete and recreate the row, and nothing would clear it: the
+  // overlay clears its keepalive before asking us to stop, so no further write
+  // for this share is coming. The reverse order — sharing switched back on
+  // while a delete is in flight — heals itself on the next keepalive beat.
+  await inflight.get(shareId)?.catch(() => undefined);
   if (!(await canPublish(shareId, "delete"))) return;
   const { error } = await supabase
     .from("live_overlays")

--- a/supabase/migrations/20260818135539_live_overlays_revoke_anon_writes.sql
+++ b/supabase/migrations/20260818135539_live_overlays_revoke_anon_writes.sql
@@ -1,0 +1,11 @@
+-- Only the desktop app writes live_overlays, and only with a logged-in session:
+-- user_id defaults to auth.uid() and every write policy is `to authenticated`.
+-- Supabase's default privileges still hand anon insert/update/delete on any
+-- table created in public, so RLS is the only thing refusing an anonymous
+-- write. Take the grants away as well, so a future policy mistake cannot open
+-- the table to the world.
+revoke insert, update, delete on public.live_overlays from anon;
+
+-- The viewer at /live/<share_id> is intentionally unauthenticated: it reads the
+-- row by its unguessable share_id and never writes. Keep that read.
+grant select on public.live_overlays to anon;


### PR DESCRIPTION
## Why

`live_overlays` is taking a steady stream of `new row violates row-level security policy` (42501 → HTTP 401) errors. Over Aug 17 14:00 → Aug 18 14:00 UTC there were **7,260** rejected `POST /rest/v1/live_overlays` against 6,837 successful ones.

Every rejected request carries `Authorization: Bearer sb_publishable_…` — the publishable key, which is what supabase-js sends when the client has no session. So the write runs as `anon`: `user_id` defaults to a null `auth.uid()` and both write policies are `to authenticated`, so no policy applies and the row is refused.

They come from exactly two clients (7.2.1 and 7.2.2) that are running **fully signed out** — neither made a single JWT-authenticated request in 24 hours. `shareEnabled`/`shareId` are persisted overlay settings that nothing clears on logout, and `liveShare.ts` keeps a 3 s keepalive with no backoff, so each client rejects ~1,300–2,000 writes an hour for as long as the overlay window is open.

This is not a regression of 41ea416 (publish from the background window, shipped in 7.2.0): that fixed the *stale token in a suspended overlay window* case. This is the adjacent one — a healthy client with no session at all.

## What changed

**`src/data/liveShareServer.ts`** — gate both the upsert and the delete on an active session (`getActiveUserId()`), and drop the message when there is none. Dropping is the right move: the overlay resends on its own beat, so a write recovers by itself the moment the user signs in. Logged once per `shareId` rather than once per beat, and the flag clears when a session appears.

**`supabase/migrations/20260818135539_live_overlays_revoke_anon_writes.sql`** — revoke `insert, update, delete` on the table from `anon`. Supabase's default privileges hand those out on every table created in `public`, which is why these requests reached Postgres at all instead of being refused at the grant level; RLS was the only thing saying no.

## Blast radius of the revoke

- The unauthenticated viewer (`LiveShareView.tsx`) only ever `select`s, and the migration keeps `grant select … to anon`.
- Every successful write in the last 24 h carried a user JWT — no anon write path exists to break.
- No edge function references `live_overlays`; no `cron.job` touches it.
- `authenticated` and `service_role` grants are untouched.

## Not applied yet

The migration is in the PR but has **not** been pushed to production — `supabase db push` after merge, under the version its filename already carries.

## Note on log volume

The gate is what stops the noise, and only for clients that update. The revoke is defense in depth: an `anon` request would still be refused (and still logged) — just at the privilege level rather than by RLS alone. Existing 7.2.x installs keep retrying until they update.

## Testing

`tsc --noEmit` clean, `eslint` clean on the changed file, `CI=true npm run jest:ci` → 27 suites / 128 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unauthenticated users from publishing or deleting live overlay updates.
  * Preserved anonymous viewing access to live overlays.
  * Improved handling and reporting of overlay update errors.
  * Prevented overlapping overlay updates from conflicting.
  * Ensured overlay updates can resume correctly after authentication is restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->